### PR TITLE
feat: implement core MVP gaps — type checking, file copy, config includes, answers persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,12 +1487,14 @@ name = "repo-weaver-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "glob",
  "home",
  "repo-weaver-ops",
  "serde",
  "serde_json",
  "serde_yml",
  "sha2",
+ "tempfile",
  "tera",
  "thiserror 2.0.17",
  "tracing",

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use repo_weaver_core::app::App;
 use repo_weaver_core::config::{ModuleManifest, WeaverConfig};
+use repo_weaver_core::engine::Engine;
 use repo_weaver_core::module::ModuleResolver;
 use repo_weaver_core::state::{
     FileState, State, calculate_checksum, calculate_checksum_from_bytes,
@@ -38,7 +39,7 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
     if !config_path.exists() {
         anyhow::bail!("weaver.yaml not found");
     }
-    let config = WeaverConfig::load(config_path)?;
+    let config = WeaverConfig::load_with_includes(config_path)?;
 
     // Load State
     let state_path = Path::new(".rw/state.yaml");
@@ -46,7 +47,7 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
 
     // 2. Init components
     let resolver = ModuleResolver::new(None)?;
-    let _template_engine = TemplateEngine::new()?;
+    let template_engine = TemplateEngine::new()?;
     let tera_context = tera::Context::new();
 
     // 3. Process Apps
@@ -65,20 +66,23 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
 
         // Resolve missing inputs (Interactive)
         let answers_path = Path::new(".rw/answers.yaml");
+        let interactive = !args.auto_approve;
         let resolved_inputs = crate::prompts::resolve_missing_inputs(
             &manifest,
             &app_config.inputs,
-            !args.auto_approve, // Interactive if not auto-approve?
-            // Spec says "Interactive Prompts". Usually implied by TTY access.
-            // But auto_approve flag usually refers to confirmation.
-            // Let's assume always interactive unless auto-approve is specified?
-            // Or maybe separate --no-input flag?
-            // "System checks... if interactive... prompt".
-            // auto_approve skips "Review Plan? [y/N]".
-            // Missing variables should probably block even in auto-approve unless defaults exist.
-            // If auto-approve is on, we are likely non-interactive.
-            // Let's allow prompting unless auto_approve is true (non-interactive mode).
+            interactive,
             &answers_path,
+            &app_config.name,
+        )?;
+
+        // Clean up stale answers for removed inputs
+        let current_keys: std::collections::HashSet<String> =
+            manifest.inputs.keys().cloned().collect();
+        crate::prompts::cleanup_stale_answers(
+            &answers_path,
+            &app_config.name,
+            &current_keys,
+            interactive,
         )?;
 
         // Merge resolved inputs into config clone
@@ -128,23 +132,10 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
 
                     // Write File
                     if dry_run {
-                        // Just log
                         info!("Would copy {:?} to {:?}", entry.path(), dest_path);
                     } else {
-                        if !dest_path.exists() {
-                            if let Some(parent) = dest_path.parent() {
-                                std::fs::create_dir_all(parent)?;
-                            }
-                        } else if args.strategy == "stop" && !args.auto_approve {
-                            // Double check: if it exists, it might be identical.
-                            // Or it is unmanaged.
-                            // But if we passed drift check above (managed & matched), we are fine.
-                            // If unmanaged (not in state), we are taking ownership.
-                        }
+                        Engine::ensure_file_copy(entry.path(), &dest_path)?;
 
-                        std::fs::copy(entry.path(), &dest_path)?;
-
-                        // Update State
                         let new_chk = calculate_checksum(&dest_path)?;
                         state.files.insert(
                             dest_path.clone(),
@@ -169,8 +160,21 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                     let content = std::fs::read_to_string(entry.path())?;
                     let mut context = tera_context.clone();
                     for (k, v) in &app.inputs {
-                        // TODO: handle types properly
-                        context.insert(k, v);
+                        match v {
+                            serde_yml::Value::String(s) => context.insert(k, s),
+                            serde_yml::Value::Number(n) => {
+                                if let Some(i) = n.as_i64() {
+                                    context.insert(k, &i);
+                                } else if let Some(f) = n.as_f64() {
+                                    context.insert(k, &f);
+                                }
+                            }
+                            serde_yml::Value::Bool(b) => context.insert(k, b),
+                            other => {
+                                let s = serde_yml::to_string(other).unwrap_or_default();
+                                context.insert(k, &s);
+                            }
+                        }
                     }
                     // Basic rendering, should use template_engine properly
                     // For MVP just text replacement logic or tera one-off?
@@ -220,13 +224,13 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                     if dry_run {
                         info!("Would render {:?} to {:?}", entry.path(), dest_path);
                     } else {
+                        let rendered = template_engine.render(&content, &context)?;
                         if let Some(parent) = dest_path.parent() {
                             std::fs::create_dir_all(parent)?;
                         }
-                        // Write content (simulated render)
-                        std::fs::write(&dest_path, &content)?; // Todo: Render
+                        std::fs::write(&dest_path, &rendered)?;
 
-                        let new_chk = calculate_checksum_from_bytes(content.as_bytes());
+                        let new_chk = calculate_checksum_from_bytes(rendered.as_bytes());
                         state.files.insert(
                             dest_path.clone(),
                             FileState {

--- a/crates/cli/src/prompts.rs
+++ b/crates/cli/src/prompts.rs
@@ -1,43 +1,108 @@
-use dialoguer::{Input, theme::ColorfulTheme};
+use dialoguer::{theme::ColorfulTheme, Input};
 use repo_weaver_core::config::ModuleManifest;
 use serde_yml::Value;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
-pub fn load_answers(path: &Path) -> anyhow::Result<HashMap<String, Value>> {
-    if path.exists() {
-        let content = fs::read_to_string(path)?;
-        // Use BTreeMap for stable ordering if we want, but HashMap is fine for internal use.
-        // Serde yaml returns a Value or a Map? from_str can parse into HashMap.
-        let answers: HashMap<String, Value> = serde_yml::from_str(&content)?;
-        Ok(answers)
-    } else {
-        Ok(HashMap::new())
+type AnswersMap = HashMap<String, HashMap<String, Value>>;
+
+pub fn load_answers(path: &Path) -> anyhow::Result<AnswersMap> {
+    if !path.exists() {
+        return Ok(HashMap::new());
     }
+    let content = fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Try parsing as namespaced format first
+    if let Ok(answers) = serde_yml::from_str::<AnswersMap>(&content) {
+        return Ok(answers);
+    }
+
+    // Legacy flat format migration: wrap in "_default" namespace
+    if let Ok(flat) = serde_yml::from_str::<HashMap<String, Value>>(&content) {
+        let mut migrated = HashMap::new();
+        migrated.insert("_default".to_string(), flat);
+        return Ok(migrated);
+    }
+
+    Ok(HashMap::new())
 }
 
-pub fn save_answers(path: &Path, answers: &HashMap<String, Value>) -> anyhow::Result<()> {
-    // Merge with existing? Or assumes caller handles merging?
-    // Usually we read all, update, save all.
-    // Let's implement logical update: read existing, merge new, save.
+pub fn save_answers(
+    path: &Path,
+    app_name: &str,
+    answers: &HashMap<String, Value>,
+) -> anyhow::Result<()> {
+    let mut all = load_answers(path).unwrap_or_default();
 
-    let mut current = load_answers(path).unwrap_or_default();
+    let app_answers = all.entry(app_name.to_string()).or_default();
     for (k, v) in answers {
-        current.insert(k.clone(), v.clone());
+        app_answers.insert(k.clone(), v.clone());
     }
 
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    // Sort keys for stability? BTreeMap?
-    // Let's convert to BTreeMap for saving.
-    let sorted: BTreeMap<_, _> = current.into_iter().collect();
+    // Sort for stable output
+    let sorted: BTreeMap<_, BTreeMap<_, _>> = all
+        .into_iter()
+        .map(|(k, v)| (k, v.into_iter().collect()))
+        .collect();
 
     let content = serde_yml::to_string(&sorted)?;
     fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn cleanup_stale_answers(
+    path: &Path,
+    app_name: &str,
+    current_keys: &HashSet<String>,
+    interactive: bool,
+) -> anyhow::Result<()> {
+    let mut all = load_answers(path).unwrap_or_default();
+    let Some(app_answers) = all.get_mut(app_name) else {
+        return Ok(());
+    };
+
+    let stale: Vec<String> = app_answers
+        .keys()
+        .filter(|k| !current_keys.contains(k.as_str()))
+        .cloned()
+        .collect();
+
+    if stale.is_empty() {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        "App '{}': stale answers found for removed inputs: {:?}",
+        app_name,
+        stale
+    );
+
+    let should_remove = if interactive {
+        let theme = ColorfulTheme::default();
+        dialoguer::Confirm::with_theme(&theme)
+            .with_prompt("Remove stale answers?")
+            .default(false)
+            .interact()?
+    } else {
+        false
+    };
+
+    if should_remove {
+        for k in &stale {
+            app_answers.remove(k);
+        }
+        save_answers(path, app_name, &HashMap::new())?;
+        tracing::info!("Removed stale answers for app '{}'", app_name);
+    }
+
     Ok(())
 }
 
@@ -46,12 +111,13 @@ pub fn resolve_missing_inputs(
     provided_inputs: &HashMap<String, Value>,
     interactive: bool,
     answers_file: &Path,
+    app_name: &str,
 ) -> anyhow::Result<HashMap<String, Value>> {
     let mut resolved = HashMap::new();
     let theme = ColorfulTheme::default();
 
-    // Load previously saved answers
-    let saved_answers = load_answers(answers_file).unwrap_or_default();
+    let all_answers = load_answers(answers_file).unwrap_or_default();
+    let saved_answers = all_answers.get(app_name).cloned().unwrap_or_default();
     let mut new_answers = HashMap::new();
 
     for (key, def) in &manifest.inputs {
@@ -69,7 +135,6 @@ pub fn resolve_missing_inputs(
 
         // 3. Default?
         if let Some(default_val) = &def.default {
-            // If default exists, use it.
             resolved.insert(key.clone(), default_val.clone());
             continue;
         }
@@ -92,15 +157,92 @@ pub fn resolve_missing_inputs(
             .with_prompt(&prompt_text)
             .interact_text()?;
 
-        let val = Value::String(input_str);
+        let val = match def.r#type.as_str() {
+            "number" => {
+                let n: f64 = input_str.parse().map_err(|_| {
+                    anyhow::anyhow!("Expected a number for '{}', got '{}'", key, input_str)
+                })?;
+                Value::Number(serde_yml::Number::from(n as i64))
+            }
+            "bool" => {
+                let b: bool = input_str.parse().map_err(|_| {
+                    anyhow::anyhow!("Expected true/false for '{}', got '{}'", key, input_str)
+                })?;
+                Value::Bool(b)
+            }
+            _ => Value::String(input_str),
+        };
         resolved.insert(key.clone(), val.clone());
         new_answers.insert(key.clone(), val);
     }
 
     // Save newly collected answers
     if !new_answers.is_empty() {
-        save_answers(answers_file, &new_answers)?;
+        save_answers(answers_file, app_name, &new_answers)?;
     }
 
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_namespaced_answers_isolation() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        let mut answers_a = HashMap::new();
+        answers_a.insert("key1".to_string(), Value::String("val_a".into()));
+        save_answers(path, "app-a", &answers_a).unwrap();
+
+        let mut answers_b = HashMap::new();
+        answers_b.insert("key1".to_string(), Value::String("val_b".into()));
+        save_answers(path, "app-b", &answers_b).unwrap();
+
+        let loaded = load_answers(path).unwrap();
+        assert_eq!(
+            loaded.get("app-a").unwrap().get("key1").unwrap(),
+            &Value::String("val_a".into())
+        );
+        assert_eq!(
+            loaded.get("app-b").unwrap().get("key1").unwrap(),
+            &Value::String("val_b".into())
+        );
+    }
+
+    #[test]
+    fn test_legacy_flat_migration() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+        std::fs::write(path, "key1: value1\nkey2: value2\n").unwrap();
+
+        let loaded = load_answers(path).unwrap();
+        let default_ns = loaded.get("_default").unwrap();
+        assert_eq!(
+            default_ns.get("key1").unwrap(),
+            &Value::String("value1".into())
+        );
+    }
+
+    #[test]
+    fn test_cleanup_stale_answers_noninteractive() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        let mut answers = HashMap::new();
+        answers.insert("current".to_string(), Value::String("v".into()));
+        answers.insert("stale_key".to_string(), Value::String("old".into()));
+        save_answers(path, "my-app", &answers).unwrap();
+
+        let current_keys: HashSet<String> = ["current".to_string()].into_iter().collect();
+        // Non-interactive: should warn but not remove
+        cleanup_stale_answers(path, "my-app", &current_keys, false).unwrap();
+
+        let loaded = load_answers(path).unwrap();
+        // Stale key still present (non-interactive doesn't remove)
+        assert!(loaded.get("my-app").unwrap().contains_key("stale_key"));
+    }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,3 +17,7 @@ home = "0.5.9"
 sha2 = "0.10.9"
 urlencoding = "2.1.3"
 repo-weaver-ops.workspace = true
+glob = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -8,12 +8,33 @@ pub struct App {
     pub inputs: HashMap<String, serde_yml::Value>,
 }
 
+fn validate_input_type(
+    key: &str,
+    value: &serde_yml::Value,
+    expected_type: &str,
+) -> anyhow::Result<()> {
+    let ok = match expected_type {
+        "string" => value.is_string(),
+        "number" => value.is_number(),
+        "bool" => value.is_bool(),
+        other => anyhow::bail!("Unknown input type '{}' for key '{}'", other, key),
+    };
+    if !ok {
+        anyhow::bail!(
+            "Input '{}': expected type '{}', got {:?}",
+            key,
+            expected_type,
+            value
+        );
+    }
+    Ok(())
+}
+
 impl App {
     pub fn instantiate(config: &AppConfig, manifest: &ModuleManifest) -> anyhow::Result<Self> {
         let mut final_inputs = HashMap::new();
 
         for (key, def) in &manifest.inputs {
-            // Check provided input OR default
             let val = config.inputs.get(key).or(def.default.as_ref());
 
             if val.is_none() && def.required {
@@ -26,21 +47,50 @@ impl App {
             }
 
             if let Some(v) = val {
-                // TODO: Type checking against def.type
+                validate_input_type(key, v, &def.r#type)?;
                 final_inputs.insert(key.clone(), v.clone());
             }
         }
-
-        // Also include inputs that might be passed but not strictly in manifest?
-        // Usually strict validation warnings. For now, allow extra inputs?
-        // Spec says "Validation rules defined for inputs". Strict is safer.
-        // For MVP, just taking what matches manifest is safer or checking mismatch.
-        // I'll stick to manifest-driven collection.
 
         Ok(Self {
             name: config.name.clone(),
             path: PathBuf::from(&config.path),
             inputs: final_inputs,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_yml::Value;
+
+    #[test]
+    fn test_validate_string_ok() {
+        assert!(validate_input_type("k", &Value::String("hi".into()), "string").is_ok());
+    }
+
+    #[test]
+    fn test_validate_number_ok() {
+        assert!(validate_input_type("k", &Value::Number(42.into()), "number").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bool_ok() {
+        assert!(validate_input_type("k", &Value::Bool(true), "bool").is_ok());
+    }
+
+    #[test]
+    fn test_validate_type_mismatch() {
+        let err = validate_input_type("port", &Value::String("not_a_number".into()), "number");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("expected type 'number'"));
+    }
+
+    #[test]
+    fn test_validate_unknown_type() {
+        let err = validate_input_type("k", &Value::String("x".into()), "object");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("Unknown input type"));
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,9 +1,23 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WeaverConfig {
     pub version: String,
+    #[serde(default)]
+    pub includes: Vec<String>,
+    #[serde(default)]
+    pub modules: Vec<ModuleConfig>,
+    #[serde(default)]
+    pub apps: Vec<AppConfig>,
+    #[serde(default)]
+    pub secrets: HashMap<String, SecretConfig>,
+}
+
+/// A config fragment loaded from includes or weaver.d/ — version is optional.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WeaverConfigFragment {
     #[serde(default)]
     pub modules: Vec<ModuleConfig>,
     #[serde(default)]
@@ -13,10 +27,64 @@ pub struct WeaverConfig {
 }
 
 impl WeaverConfig {
-    pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = serde_yml::from_str(&content)?;
         Ok(config)
+    }
+
+    pub fn load_with_includes(path: &Path) -> anyhow::Result<Self> {
+        let mut config = Self::load(path)?;
+        let base_dir = path.parent().unwrap_or(Path::new("."));
+
+        // Collect include paths from explicit includes field
+        let mut include_paths = Vec::new();
+        for pattern in &config.includes {
+            let full_pattern = base_dir.join(pattern);
+            let pattern_str = full_pattern.to_string_lossy().to_string();
+            for entry in glob::glob(&pattern_str)? {
+                let p = entry?;
+                if p.is_file() {
+                    include_paths.push(p);
+                }
+            }
+        }
+
+        // Auto-discover weaver.d/*.yaml
+        let weaver_d = base_dir.join("weaver.d");
+        if weaver_d.is_dir() {
+            let pattern = weaver_d.join("*.yaml");
+            let pattern_str = pattern.to_string_lossy().to_string();
+            for entry in glob::glob(&pattern_str)? {
+                let p = entry?;
+                if p.is_file() && !include_paths.contains(&p) {
+                    include_paths.push(p);
+                }
+            }
+        }
+
+        // Sort for deterministic ordering
+        include_paths.sort();
+
+        // Merge fragments
+        for inc_path in &include_paths {
+            let content = std::fs::read_to_string(inc_path)?;
+            let fragment: WeaverConfigFragment = serde_yml::from_str(&content)?;
+            config.merge_fragment(fragment);
+        }
+
+        Ok(config)
+    }
+
+    fn merge_fragment(&mut self, fragment: WeaverConfigFragment) {
+        // Arrays: concatenate
+        self.modules.extend(fragment.modules);
+        self.apps.extend(fragment.apps);
+
+        // Maps: later wins
+        for (k, v) in fragment.secrets {
+            self.secrets.insert(k, v);
+        }
     }
 }
 
@@ -24,7 +92,7 @@ impl WeaverConfig {
 pub struct ModuleConfig {
     pub name: String,
     pub source: String,
-    pub r#ref: String, // "ref" is a keyword in some languages, but okay in Rust struct field? No, "ref" is keyword. Use raw identifier.
+    pub r#ref: String,
     #[serde(default)]
     pub path: Option<String>,
 }
@@ -75,4 +143,174 @@ pub struct InputDef {
 pub struct TaskDef {
     pub command: String,
     pub description: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_single_file_no_includes() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("weaver.yaml");
+        fs::write(
+            &config_path,
+            r#"
+version: "1.0"
+modules:
+  - name: base
+    source: "https://example.com/mod"
+    ref: "v1.0"
+apps:
+  - name: my-app
+    module: base
+    path: "."
+"#,
+        )
+        .unwrap();
+
+        let config = WeaverConfig::load_with_includes(&config_path).unwrap();
+        assert_eq!(config.modules.len(), 1);
+        assert_eq!(config.apps.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_modules_concatenate() {
+        let dir = TempDir::new().unwrap();
+        let weaver_d = dir.path().join("weaver.d");
+        fs::create_dir(&weaver_d).unwrap();
+
+        let config_path = dir.path().join("weaver.yaml");
+        fs::write(
+            &config_path,
+            r#"
+version: "1.0"
+modules:
+  - name: base
+    source: "https://example.com/base"
+    ref: "v1"
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            weaver_d.join("extra.yaml"),
+            r#"
+modules:
+  - name: extra
+    source: "https://example.com/extra"
+    ref: "v2"
+apps:
+  - name: extra-app
+    module: extra
+    path: "./extra"
+"#,
+        )
+        .unwrap();
+
+        let config = WeaverConfig::load_with_includes(&config_path).unwrap();
+        assert_eq!(config.modules.len(), 2);
+        assert_eq!(config.modules[0].name, "base");
+        assert_eq!(config.modules[1].name, "extra");
+        assert_eq!(config.apps.len(), 1);
+        assert_eq!(config.apps[0].name, "extra-app");
+    }
+
+    #[test]
+    fn test_merge_secrets_override() {
+        let dir = TempDir::new().unwrap();
+        let weaver_d = dir.path().join("weaver.d");
+        fs::create_dir(&weaver_d).unwrap();
+
+        let config_path = dir.path().join("weaver.yaml");
+        fs::write(
+            &config_path,
+            r#"
+version: "1.0"
+secrets:
+  db_password:
+    provider: env
+    key: DB_PASS
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            weaver_d.join("secrets.yaml"),
+            r#"
+secrets:
+  db_password:
+    provider: aws-ssm
+    key: /prod/db/password
+"#,
+        )
+        .unwrap();
+
+        let config = WeaverConfig::load_with_includes(&config_path).unwrap();
+        let secret = config.secrets.get("db_password").unwrap();
+        assert_eq!(secret.provider, "aws-ssm");
+        assert_eq!(secret.key, "/prod/db/password");
+    }
+
+    #[test]
+    fn test_include_glob_pattern() {
+        let dir = TempDir::new().unwrap();
+        let conf_dir = dir.path().join("conf");
+        fs::create_dir(&conf_dir).unwrap();
+
+        let config_path = dir.path().join("weaver.yaml");
+        fs::write(
+            &config_path,
+            r#"
+version: "1.0"
+includes:
+  - "conf/*.yaml"
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            conf_dir.join("apps.yaml"),
+            r#"
+apps:
+  - name: from-include
+    module: base
+    path: "./inc"
+"#,
+        )
+        .unwrap();
+
+        let config = WeaverConfig::load_with_includes(&config_path).unwrap();
+        assert_eq!(config.apps.len(), 1);
+        assert_eq!(config.apps[0].name, "from-include");
+    }
+
+    #[test]
+    fn test_deterministic_ordering() {
+        let dir = TempDir::new().unwrap();
+        let weaver_d = dir.path().join("weaver.d");
+        fs::create_dir(&weaver_d).unwrap();
+
+        let config_path = dir.path().join("weaver.yaml");
+        fs::write(&config_path, "version: \"1.0\"\n").unwrap();
+
+        fs::write(
+            weaver_d.join("b.yaml"),
+            "apps:\n  - name: b-app\n    module: m\n    path: b\n",
+        )
+        .unwrap();
+        fs::write(
+            weaver_d.join("a.yaml"),
+            "apps:\n  - name: a-app\n    module: m\n    path: a\n",
+        )
+        .unwrap();
+
+        let config = WeaverConfig::load_with_includes(&config_path).unwrap();
+        assert_eq!(config.apps.len(), 2);
+        // a.yaml sorts before b.yaml
+        assert_eq!(config.apps[0].name, "a-app");
+        assert_eq!(config.apps[1].name, "b-app");
+    }
 }

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -23,6 +23,10 @@ impl Engine {
         Ok(())
     }
 
+    pub fn ensure_file_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
+        repo_weaver_ops::fs::copy_file(src, dest)
+    }
+
     pub fn ensure_task_wrapper(path: &Path, command: &str) -> anyhow::Result<()> {
         let content = format!("#!/bin/sh\nexec {}\n", command);
         if let Some(parent) = path.parent() {

--- a/crates/core/src/plugin/wasm.rs
+++ b/crates/core/src/plugin/wasm.rs
@@ -25,10 +25,7 @@ impl weaver::plugin::process::Host for Host {
     fn exec(
         &mut self,
         req: weaver::plugin::process::ExecRequest,
-    ) -> wasmtime::Result<Result<weaver::plugin::process::ExecResult, String>> {
-        // Policy: Allowlist? For MVP, we allow everything but could restrict.
-        // Spec says "Host can reject...". For now, we trust the plugin in MVP.
-
+    ) -> Result<weaver::plugin::process::ExecResult, String> {
         let mut cmd = Command::new(&req.program);
         cmd.args(&req.args);
 
@@ -52,29 +49,27 @@ impl weaver::plugin::process::Host for Host {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => return Ok(Err(format!("Failed to spawn {}: {}", req.program, e))),
-        };
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn {}: {}", req.program, e))?;
 
         if let Some(input) = &req.stdin {
             if let Some(mut s) = child.stdin.take() {
-                if let Err(e) = s.write_all(input) {
-                    return Ok(Err(format!("Failed to write stdin: {}", e)));
-                }
+                s.write_all(input)
+                    .map_err(|e| format!("Failed to write stdin: {}", e))?;
             }
         }
 
         let output = child
             .wait_with_output()
-            .map_err(|e| anyhow::anyhow!("Failed to wait on child: {}", e))?;
+            .map_err(|e| format!("Failed to wait on child: {}", e))?;
         let code = output.status.code().unwrap_or(1) as u32;
 
-        Ok(Ok(weaver::plugin::process::ExecResult {
+        Ok(weaver::plugin::process::ExecResult {
             status: code,
             stdout: output.stdout,
             stderr: output.stderr,
-        }))
+        })
     }
 }
 

--- a/crates/ops/src/fs.rs
+++ b/crates/ops/src/fs.rs
@@ -15,3 +15,11 @@ pub fn copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
     fs_extra::dir::copy(src, dest, &options)?;
     Ok(())
 }
+
+pub fn copy_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = dest.parent() {
+        ensure_dir(parent)?;
+    }
+    std::fs::copy(src, dest)?;
+    Ok(())
+}


### PR DESCRIPTION
- Add input type validation (string/number/bool) in App::instantiate with
  proper Tera context insertion and type-aware prompt parsing
- Add ensure.file.copy engine action backed by ops::fs::copy_file
- Fix template rendering bug: apply.rs now renders through Tera instead of
  writing raw template content
- Namespace answers per app in .rw/answers.yaml with stale answer cleanup
  and legacy flat-format migration
- Add config includes support: weaver.yaml `includes` field with glob
  patterns and automatic weaver.d/ fragment discovery with deterministic
  merge (arrays concatenate, maps override)
- Fix pre-existing wasmtime 24.0.5 API breakage in WASM plugin host

https://claude.ai/code/session_01DmUXSQZ3EKgnkBQp5uqARL