### PR TITLE
Add examples 11-14 for drift, plan exit codes, plan-file safety, and task args

### DIFF
--- a/examples/11-apply-stop-on-drift/README.md
+++ b/examples/11-apply-stop-on-drift/README.md
@@ -1,0 +1,28 @@
+# 11 - Apply Stop on Drift
+
+Demonstrates the default `rw apply` drift behavior (`--strategy stop`): detect drift,
+fail fast, and preserve local edits.
+
+## What this covers
+
+- `rw apply` default conflict strategy (`stop`) (CLI contract: `rw apply`)
+- Drift safety when managed files are manually edited
+- No filesystem mutations when apply aborts on drift
+
+## Before state
+
+- `app/deployment.yaml` was manually changed from `replicas: 2` to `replicas: 5`
+- `.rw/state.yaml` still tracks the original generated checksum
+
+## How to run
+
+```sh
+cd before
+rw apply
+```
+
+## Expected result
+
+`rw apply` exits with a drift error, and `before/` remains unchanged (matching `after/`):
+- `app/deployment.yaml` keeps the user edit (`replicas: 5`)
+- `.rw/state.yaml` is not rewritten

--- a/examples/11-apply-stop-on-drift/after/.rw/state.yaml
+++ b/examples/11-apply-stop-on-drift/after/.rw/state.yaml
@@ -1,0 +1,6 @@
+version: 1
+files:
+  app/deployment.yaml:
+    checksum: "46cf36eb4bfb155547f875a3ee38e14a1b44d54c7de180d4048337c2852cfd17"
+    source: "k8s-base:files/deployment.yaml"
+    managed: true

--- a/examples/11-apply-stop-on-drift/after/app/deployment.yaml
+++ b/examples/11-apply-stop-on-drift/after/app/deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+spec:
+  replicas: 5
+  template:
+    spec:
+      containers:
+        - name: checkout
+          image: ghcr.io/acme/checkout:1.4.0

--- a/examples/11-apply-stop-on-drift/after/weaver.yaml
+++ b/examples/11-apply-stop-on-drift/after/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "k8s-base"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "checkout"
+    module: "k8s-base"
+    path: "app"
+    inputs: {}

--- a/examples/11-apply-stop-on-drift/before/.rw/state.yaml
+++ b/examples/11-apply-stop-on-drift/before/.rw/state.yaml
@@ -1,0 +1,6 @@
+version: 1
+files:
+  app/deployment.yaml:
+    checksum: "46cf36eb4bfb155547f875a3ee38e14a1b44d54c7de180d4048337c2852cfd17"
+    source: "k8s-base:files/deployment.yaml"
+    managed: true

--- a/examples/11-apply-stop-on-drift/before/app/deployment.yaml
+++ b/examples/11-apply-stop-on-drift/before/app/deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+spec:
+  replicas: 5
+  template:
+    spec:
+      containers:
+        - name: checkout
+          image: ghcr.io/acme/checkout:1.4.0

--- a/examples/11-apply-stop-on-drift/before/weaver.yaml
+++ b/examples/11-apply-stop-on-drift/before/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "k8s-base"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "checkout"
+    module: "k8s-base"
+    path: "app"
+    inputs: {}

--- a/examples/11-apply-stop-on-drift/module/files/deployment.yaml
+++ b/examples/11-apply-stop-on-drift/module/files/deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: checkout
+          image: ghcr.io/acme/checkout:1.4.0

--- a/examples/12-plan-detailed-exitcode/README.md
+++ b/examples/12-plan-detailed-exitcode/README.md
@@ -1,0 +1,27 @@
+# 12 - Plan Detailed Exit Code
+
+Demonstrates `rw plan --detailed-exitcode` when drift is detected in a managed file.
+
+## What this covers
+
+- `rw plan --detailed-exitcode` behavior (exit code `2` on detected changes)
+- Drift reporting without mutating workspace files
+- CI-oriented plan checks
+
+## Before state
+
+- `app/settings.yaml` was manually edited (`retries: 7`)
+- Module source still defines `retries: 3`
+- `.rw/state.yaml` tracks the original generated checksum
+
+## How to run
+
+```sh
+cd before
+rw plan --detailed-exitcode
+```
+
+## Expected result
+
+`rw plan` reports drift and exits with code `2`. Workspace contents are unchanged,
+so `before/` should still match `after/`.

--- a/examples/12-plan-detailed-exitcode/after/.rw/state.yaml
+++ b/examples/12-plan-detailed-exitcode/after/.rw/state.yaml
@@ -1,0 +1,6 @@
+version: 1
+files:
+  app/settings.yaml:
+    checksum: "86fd62c27bfe0cfbb182d0473ea41a8511fe9c3db8ffb98aeb3d14021bd65932"
+    source: "service-config:files/settings.yaml"
+    managed: true

--- a/examples/12-plan-detailed-exitcode/after/app/settings.yaml
+++ b/examples/12-plan-detailed-exitcode/after/app/settings.yaml
@@ -1,0 +1,3 @@
+service:
+  name: billing
+  retries: 7

--- a/examples/12-plan-detailed-exitcode/after/weaver.yaml
+++ b/examples/12-plan-detailed-exitcode/after/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "service-config"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "billing"
+    module: "service-config"
+    path: "app"
+    inputs: {}

--- a/examples/12-plan-detailed-exitcode/before/.rw/state.yaml
+++ b/examples/12-plan-detailed-exitcode/before/.rw/state.yaml
@@ -1,0 +1,6 @@
+version: 1
+files:
+  app/settings.yaml:
+    checksum: "86fd62c27bfe0cfbb182d0473ea41a8511fe9c3db8ffb98aeb3d14021bd65932"
+    source: "service-config:files/settings.yaml"
+    managed: true

--- a/examples/12-plan-detailed-exitcode/before/app/settings.yaml
+++ b/examples/12-plan-detailed-exitcode/before/app/settings.yaml
@@ -1,0 +1,3 @@
+service:
+  name: billing
+  retries: 7

--- a/examples/12-plan-detailed-exitcode/before/weaver.yaml
+++ b/examples/12-plan-detailed-exitcode/before/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "service-config"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "billing"
+    module: "service-config"
+    path: "app"
+    inputs: {}

--- a/examples/12-plan-detailed-exitcode/module/files/settings.yaml
+++ b/examples/12-plan-detailed-exitcode/module/files/settings.yaml
@@ -1,0 +1,3 @@
+service:
+  name: billing
+  retries: 3

--- a/examples/13-plan-out-file/README.md
+++ b/examples/13-plan-out-file/README.md
@@ -1,0 +1,36 @@
+# 13 - Plan Output File Safety Check
+
+Demonstrates plan-file safety semantics inspired by Terraform workflows: if the
+workspace changes after `rw plan --out`, `rw apply` with that saved plan must fail
+instead of applying stale intent.
+
+## What this covers
+
+- `rw plan --out` creates a reusable plan artifact
+- `rw apply --plan <file>` validates the workspace fingerprint before applying
+- Apply fails safely when config/input drift occurs between plan and apply
+
+## Before state
+
+This fixture represents a workspace **after** a plan was generated and **after**
+someone edited `weaver.yaml`:
+
+- Saved plan (`.rw/plan.json`) was created with `retention_days: 30`
+- Current `weaver.yaml` now has `retention_days: 90`
+- `app/policies.yaml` has not been written yet
+
+## How to run
+
+```sh
+cd before
+rw apply --plan .rw/plan.json
+```
+
+## Expected result
+
+`rw apply --plan .rw/plan.json` fails with a stale-plan error (fingerprint/input
+mismatch), and no files are changed:
+
+- `app/policies.yaml` remains absent
+- `.rw/plan.json` remains unchanged
+- Workspace still matches `after/`

--- a/examples/13-plan-out-file/after/.rw/plan.json
+++ b/examples/13-plan-out-file/after/.rw/plan.json
@@ -1,0 +1,20 @@
+{
+  "format_version": "1",
+  "created_at": "2026-03-31T08:30:00Z",
+  "workspace_fingerprint": "sha256:3f11b3f8e8f9e13f9f4e3f6f6ec22a0d0ba7fc2f4fbb8f3411c1377d95a0ad88",
+  "planned_inputs": {
+    "org-policy.retention_days": 30
+  },
+  "changes": [
+    {
+      "action": "add",
+      "path": "app/policies.yaml",
+      "preview": {
+        "policies": [
+          {"name": "audit-log-retention", "days": 30},
+          {"name": "require-2fa", "enabled": true}
+        ]
+      }
+    }
+  ]
+}

--- a/examples/13-plan-out-file/after/weaver.yaml
+++ b/examples/13-plan-out-file/after/weaver.yaml
@@ -1,0 +1,11 @@
+version: "1"
+modules:
+  - name: "policy-pack"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "org-policy"
+    module: "policy-pack"
+    path: "app"
+    inputs:
+      retention_days: 90

--- a/examples/13-plan-out-file/before/.rw/plan.json
+++ b/examples/13-plan-out-file/before/.rw/plan.json
@@ -1,0 +1,20 @@
+{
+  "format_version": "1",
+  "created_at": "2026-03-31T08:30:00Z",
+  "workspace_fingerprint": "sha256:3f11b3f8e8f9e13f9f4e3f6f6ec22a0d0ba7fc2f4fbb8f3411c1377d95a0ad88",
+  "planned_inputs": {
+    "org-policy.retention_days": 30
+  },
+  "changes": [
+    {
+      "action": "add",
+      "path": "app/policies.yaml",
+      "preview": {
+        "policies": [
+          {"name": "audit-log-retention", "days": 30},
+          {"name": "require-2fa", "enabled": true}
+        ]
+      }
+    }
+  ]
+}

--- a/examples/13-plan-out-file/before/weaver.yaml
+++ b/examples/13-plan-out-file/before/weaver.yaml
@@ -1,0 +1,11 @@
+version: "1"
+modules:
+  - name: "policy-pack"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "org-policy"
+    module: "policy-pack"
+    path: "app"
+    inputs:
+      retention_days: 90

--- a/examples/13-plan-out-file/module/templates/policies.yaml.j2
+++ b/examples/13-plan-out-file/module/templates/policies.yaml.j2
@@ -1,0 +1,5 @@
+policies:
+  - name: audit-log-retention
+    days: {{ retention_days }}
+  - name: require-2fa
+    enabled: true

--- a/examples/13-plan-out-file/module/weaver.module.yaml
+++ b/examples/13-plan-out-file/module/weaver.module.yaml
@@ -1,0 +1,5 @@
+inputs:
+  retention_days:
+    type: number
+    required: true
+    description: "Number of days to retain audit logs"

--- a/examples/14-run-task-with-args/README.md
+++ b/examples/14-run-task-with-args/README.md
@@ -1,0 +1,29 @@
+# 14 - Run Task with Arguments
+
+Demonstrates `rw run <app> <task> [args...]` using the app working directory and
+forwarding positional arguments to the task command.
+
+## What this covers
+
+- `rw run` task lookup from module manifest
+- Running task commands in `apps[].path`
+- Forwarding CLI args to the underlying command
+
+## Before state
+
+- Module defines a `deploy` task (`sh scripts/deploy.sh`)
+- App path is `services/payments`
+- Deployment script exists in the app workspace and writes `deploy.log`
+
+## How to run
+
+```sh
+cd before
+rw run payments deploy production us-east-1
+```
+
+## Expected result
+
+After `rw run`, the workspace should match `after/`:
+- `services/payments/deploy.log` is created by the task command
+- Log content includes forwarded args (`production`, `us-east-1`)

--- a/examples/14-run-task-with-args/after/services/payments/scripts/deploy.sh
+++ b/examples/14-run-task-with-args/after/services/payments/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+env_name="$1"
+region="$2"
+
+cat > deploy.log <<LOG
+Deploying payments service
+Environment: ${env_name}
+Region: ${region}
+LOG

--- a/examples/14-run-task-with-args/after/weaver.yaml
+++ b/examples/14-run-task-with-args/after/weaver.yaml
@@ -1,0 +1,11 @@
+version: "1"
+modules:
+  - name: "payments-ops"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "payments"
+    module: "payments-ops"
+    path: "services/payments"
+    inputs:
+      region: "us-east-1"

--- a/examples/14-run-task-with-args/before/services/payments/scripts/deploy.sh
+++ b/examples/14-run-task-with-args/before/services/payments/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+env_name="$1"
+region="$2"
+
+cat > deploy.log <<LOG
+Deploying payments service
+Environment: ${env_name}
+Region: ${region}
+LOG

--- a/examples/14-run-task-with-args/before/weaver.yaml
+++ b/examples/14-run-task-with-args/before/weaver.yaml
@@ -1,0 +1,11 @@
+version: "1"
+modules:
+  - name: "payments-ops"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "payments"
+    module: "payments-ops"
+    path: "services/payments"
+    inputs:
+      region: "us-east-1"

--- a/examples/14-run-task-with-args/module/weaver.module.yaml
+++ b/examples/14-run-task-with-args/module/weaver.module.yaml
@@ -1,0 +1,9 @@
+inputs:
+  region:
+    type: string
+    required: true
+    description: "Default deployment region"
+tasks:
+  deploy:
+    description: "Run the deployment helper"
+    command: "sh scripts/deploy.sh"


### PR DESCRIPTION
### Motivation

- Add reproducible workspace fixtures that demonstrate runtime behaviors around drift detection, plan exit codes, plan-file safety, and task argument forwarding. 

### Description

- Add example `11-apply-stop-on-drift` that shows `rw apply` default `--strategy stop` behavior with `before/` and `after/` workspaces and a module file (`module/files/deployment.yaml`) representing the generated source. 
- Add example `12-plan-detailed-exitcode` that demonstrates `rw plan --detailed-exitcode` drift reporting with managed file checksums and `before/`/`after/` fixtures and module settings. 
- Add example `13-plan-out-file` that includes a saved plan (`.rw/plan.json`), module templates, and fixtures to show that `rw apply --plan <file>` validates workspace fingerprint and fails on stale plans. 
- Add example `14-run-task-with-args` that defines a `deploy` task in `module/weaver.module.yaml` and a script `services/payments/scripts/deploy.sh` to show `rw run <app> <task> [args...]` forwarding positional args into the task command. 

### Testing

- No automated tests were run as part of this change; these additions are self-contained example fixtures intended for manual or CI-driven example validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc41299b8c8330b0f2ac561a4fae11)