### PR TITLE
Add missing CLI discovery, describe, module-update and policy check example fixtures

### DIFF
--- a/examples/18-cli-list-and-task-list/README.md
+++ b/examples/18-cli-list-and-task-list/README.md
@@ -1,0 +1,23 @@
+# 18 - CLI Discovery (`rw list` and `rw task list`)
+
+Demonstrates workspace/app discovery commands that do not mutate files.
+
+## What this covers
+
+- `rw list` app/module discovery (PRD §8)
+- `rw task list [app]` task discovery from app-local task definitions (PRD §8)
+- Non-mutating CLI workflows for CI/operator introspection
+
+## How to run
+
+```sh
+cd before
+rw list
+rw task list web
+rw task list infra
+```
+
+## Expected result
+
+`rw list` and `rw task list` should print the apps/tasks declared in `weaver.yaml`.
+Workspace files remain unchanged, so `before/` and `after/` are identical.

--- a/examples/18-cli-list-and-task-list/after/weaver.yaml
+++ b/examples/18-cli-list-and-task-list/after/weaver.yaml
@@ -1,0 +1,24 @@
+version: "1"
+modules:
+  - name: "platform-base"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "web"
+    module: "platform-base"
+    path: "services/web"
+    inputs: {}
+    tasks:
+      lint:
+        command: "echo linting web"
+      deploy:
+        command: "echo deploying web"
+  - name: "infra"
+    module: "platform-base"
+    path: "infra"
+    inputs: {}
+    tasks:
+      plan:
+        command: "echo planning infra"
+      apply:
+        command: "echo applying infra"

--- a/examples/18-cli-list-and-task-list/before/weaver.yaml
+++ b/examples/18-cli-list-and-task-list/before/weaver.yaml
@@ -1,0 +1,24 @@
+version: "1"
+modules:
+  - name: "platform-base"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "web"
+    module: "platform-base"
+    path: "services/web"
+    inputs: {}
+    tasks:
+      lint:
+        command: "echo linting web"
+      deploy:
+        command: "echo deploying web"
+  - name: "infra"
+    module: "platform-base"
+    path: "infra"
+    inputs: {}
+    tasks:
+      plan:
+        command: "echo planning infra"
+      apply:
+        command: "echo applying infra"

--- a/examples/18-cli-list-and-task-list/module/files/TEAM.md
+++ b/examples/18-cli-list-and-task-list/module/files/TEAM.md
@@ -1,0 +1,4 @@
+# Platform Team Conventions
+
+- Web app tasks should always include `lint` and `deploy`.
+- Infra app tasks should always include `plan` and `apply`.

--- a/examples/19-cli-describe-resolved-config/README.md
+++ b/examples/19-cli-describe-resolved-config/README.md
@@ -1,0 +1,25 @@
+# 19 - `rw describe` with Includes and Overrides
+
+Demonstrates resolved-config inspection for a split workspace where app policy is
+composed across `weaver.yaml` and `weaver.d/*.yaml`.
+
+## What this covers
+
+- `rw describe <app>` resolved config output after include merge (PRD §8)
+- Include-driven composition and deterministic overrides (PRD §5.2)
+- Non-mutating diagnostics for troubleshooting config inheritance
+
+## How to run
+
+```sh
+cd before
+rw describe platform
+```
+
+## Expected result
+
+`rw describe platform` should show a merged app config where:
+- global vars from `weaver.yaml` are present,
+- app-level overrides from `weaver.d/policies.yaml` win.
+
+Workspace files remain unchanged, so `before/` and `after/` are identical.

--- a/examples/19-cli-describe-resolved-config/after/weaver.d/policies.yaml
+++ b/examples/19-cli-describe-resolved-config/after/weaver.d/policies.yaml
@@ -1,0 +1,8 @@
+apps:
+  - name: "platform"
+    vars:
+      environment: "staging"
+      owner: "platform-sre"
+    checks:
+      - name: "manifest-lint"
+        run: "test -f k8s/deployment.yaml"

--- a/examples/19-cli-describe-resolved-config/after/weaver.yaml
+++ b/examples/19-cli-describe-resolved-config/after/weaver.yaml
@@ -1,0 +1,17 @@
+version: "1"
+includes:
+  - "weaver.d/*.yaml"
+modules:
+  - name: "platform"
+    source: "../module"
+    ref: "v1"
+vars:
+  owner: "platform-team"
+  cost_center: "cc-1042"
+apps:
+  - name: "platform"
+    module: "platform"
+    path: "services/platform"
+    inputs:
+      owner: "{{ vars.owner }}"
+      cost_center: "{{ vars.cost_center }}"

--- a/examples/19-cli-describe-resolved-config/before/weaver.d/policies.yaml
+++ b/examples/19-cli-describe-resolved-config/before/weaver.d/policies.yaml
@@ -1,0 +1,8 @@
+apps:
+  - name: "platform"
+    vars:
+      environment: "staging"
+      owner: "platform-sre"
+    checks:
+      - name: "manifest-lint"
+        run: "test -f k8s/deployment.yaml"

--- a/examples/19-cli-describe-resolved-config/before/weaver.yaml
+++ b/examples/19-cli-describe-resolved-config/before/weaver.yaml
@@ -1,0 +1,17 @@
+version: "1"
+includes:
+  - "weaver.d/*.yaml"
+modules:
+  - name: "platform"
+    source: "../module"
+    ref: "v1"
+vars:
+  owner: "platform-team"
+  cost_center: "cc-1042"
+apps:
+  - name: "platform"
+    module: "platform"
+    path: "services/platform"
+    inputs:
+      owner: "{{ vars.owner }}"
+      cost_center: "{{ vars.cost_center }}"

--- a/examples/19-cli-describe-resolved-config/module/files/README.md
+++ b/examples/19-cli-describe-resolved-config/module/files/README.md
@@ -1,0 +1,3 @@
+# Platform Module
+
+This module provides baseline repository docs used by all platform services.

--- a/examples/20-check-k8s-ingress-annotations/README.md
+++ b/examples/20-check-k8s-ingress-annotations/README.md
@@ -1,0 +1,31 @@
+# 20 - Kubernetes Ingress Annotation Policy (`rw check`)
+
+Demonstrates policy validation for ingress manifests: every ingress must include
+required controller and ownership annotations.
+
+## What this covers
+
+- `rw check [app]` command behavior (PRD §8)
+- Realistic policy guardrail for Kubernetes ingress standards
+- Non-mutating validation workflow for pre-merge checks
+
+## Policy intent
+
+All ingress resources must declare:
+- `kubernetes.io/ingress.class`
+- `external-dns.alpha.kubernetes.io/hostname`
+- `platform.company.io/owner`
+
+## How to run
+
+```sh
+cd before
+rw check gateway
+```
+
+## Expected result
+
+`rw check gateway` should fail in `before/` because required annotations are
+missing.
+
+`after/` shows the expected compliant state once the ingress is corrected.

--- a/examples/20-check-k8s-ingress-annotations/after/k8s/ingress.yaml
+++ b/examples/20-check-k8s-ingress-annotations/after/k8s/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payments-api
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/hostname: payments.internal.example.com
+    platform.company.io/owner: payments-team
+spec:
+  rules:
+    - host: payments.internal.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payments-api
+                port:
+                  number: 8080

--- a/examples/20-check-k8s-ingress-annotations/after/weaver.yaml
+++ b/examples/20-check-k8s-ingress-annotations/after/weaver.yaml
@@ -1,0 +1,13 @@
+version: "1"
+modules:
+  - name: "k8s-policy"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "gateway"
+    module: "k8s-policy"
+    path: "."
+    inputs: {}
+    checks:
+      - name: "ingress-required-annotations"
+        run: "rg -n 'kubernetes\.io/ingress\.class|external-dns\.alpha\.kubernetes\.io/hostname|platform\.company\.io/owner' k8s/ingress.yaml"

--- a/examples/20-check-k8s-ingress-annotations/before/k8s/ingress.yaml
+++ b/examples/20-check-k8s-ingress-annotations/before/k8s/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payments-api
+  namespace: production
+spec:
+  rules:
+    - host: payments.internal.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payments-api
+                port:
+                  number: 8080

--- a/examples/20-check-k8s-ingress-annotations/before/weaver.yaml
+++ b/examples/20-check-k8s-ingress-annotations/before/weaver.yaml
@@ -1,0 +1,13 @@
+version: "1"
+modules:
+  - name: "k8s-policy"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "gateway"
+    module: "k8s-policy"
+    path: "."
+    inputs: {}
+    checks:
+      - name: "ingress-required-annotations"
+        run: "rg -n 'kubernetes\.io/ingress\.class|external-dns\.alpha\.kubernetes\.io/hostname|platform\.company\.io/owner' k8s/ingress.yaml"

--- a/examples/20-check-k8s-ingress-annotations/module/files/POLICY.md
+++ b/examples/20-check-k8s-ingress-annotations/module/files/POLICY.md
@@ -1,0 +1,4 @@
+# Ingress Policy
+
+Ingress resources must include class, DNS, and owner annotations so traffic
+routing and ownership are explicit across clusters.

--- a/examples/21-check-terraform-ec2-tags/README.md
+++ b/examples/21-check-terraform-ec2-tags/README.md
@@ -1,0 +1,30 @@
+# 21 - Terraform EC2 Required Tags Policy (`rw check`)
+
+Demonstrates policy validation for Terraform-managed EC2 instances where all
+instances must carry mandatory governance tags.
+
+## What this covers
+
+- `rw check [app]` for infrastructure policy validation (PRD §8)
+- Realistic cloud-governance scenario (required owner/env/cost-center tags)
+- Non-mutating pre-apply checks in CI pipelines
+
+## Policy intent
+
+Every `aws_instance` resource must include:
+- `Owner`
+- `Environment`
+- `CostCenter`
+
+## How to run
+
+```sh
+cd before
+rw check compute
+```
+
+## Expected result
+
+`rw check compute` should fail in `before/` because required tags are missing.
+
+`after/` shows the expected compliant Terraform state.

--- a/examples/21-check-terraform-ec2-tags/after/infra/main.tf
+++ b/examples/21-check-terraform-ec2-tags/after/infra/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "app" {
+  ami           = "ami-0a12345b67890cdef"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name        = "orders-api"
+    Owner       = "orders-team"
+    Environment = "production"
+    CostCenter  = "cc-4821"
+  }
+}

--- a/examples/21-check-terraform-ec2-tags/after/weaver.yaml
+++ b/examples/21-check-terraform-ec2-tags/after/weaver.yaml
@@ -1,0 +1,13 @@
+version: "1"
+modules:
+  - name: "tf-policy"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "compute"
+    module: "tf-policy"
+    path: "."
+    inputs: {}
+    checks:
+      - name: "ec2-mandatory-tags"
+        run: "rg -n 'Owner\s*=|Environment\s*=|CostCenter\s*=' infra/main.tf"

--- a/examples/21-check-terraform-ec2-tags/before/infra/main.tf
+++ b/examples/21-check-terraform-ec2-tags/before/infra/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "app" {
+  ami           = "ami-0a12345b67890cdef"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "orders-api"
+  }
+}

--- a/examples/21-check-terraform-ec2-tags/before/weaver.yaml
+++ b/examples/21-check-terraform-ec2-tags/before/weaver.yaml
@@ -1,0 +1,13 @@
+version: "1"
+modules:
+  - name: "tf-policy"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "compute"
+    module: "tf-policy"
+    path: "."
+    inputs: {}
+    checks:
+      - name: "ec2-mandatory-tags"
+        run: "rg -n 'Owner\s*=|Environment\s*=|CostCenter\s*=' infra/main.tf"

--- a/examples/21-check-terraform-ec2-tags/module/files/POLICY.md
+++ b/examples/21-check-terraform-ec2-tags/module/files/POLICY.md
@@ -1,0 +1,4 @@
+# EC2 Tagging Policy
+
+All EC2 instances must declare Owner, Environment, and CostCenter tags to
+support incident routing and chargeback.

--- a/examples/22-cli-module-update-ref/README.md
+++ b/examples/22-cli-module-update-ref/README.md
@@ -1,0 +1,23 @@
+# 22 - Module Ref Bump (`rw module update`)
+
+Demonstrates the CLI workflow for bumping a pinned module reference in
+workspace config.
+
+## What this covers
+
+- `rw module list` to inspect current module refs (PRD §8)
+- `rw module update <name> --ref <newRef>` to update a pinned ref (PRD §8)
+- Update intent captured in config before running `rw apply`
+
+## How to run
+
+```sh
+cd before
+rw module list
+rw module update platform-standards --ref v2
+```
+
+## Expected result
+
+After `rw module update`, `before/weaver.yaml` should match `after/weaver.yaml`
+with the module ref changed from `v1` to `v2`.

--- a/examples/22-cli-module-update-ref/after/weaver.yaml
+++ b/examples/22-cli-module-update-ref/after/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "platform-standards"
+    source: "../module"
+    ref: "v2"
+apps:
+  - name: "catalog"
+    module: "platform-standards"
+    path: "services/catalog"
+    inputs: {}

--- a/examples/22-cli-module-update-ref/before/weaver.yaml
+++ b/examples/22-cli-module-update-ref/before/weaver.yaml
@@ -1,0 +1,10 @@
+version: "1"
+modules:
+  - name: "platform-standards"
+    source: "../module"
+    ref: "v1"
+apps:
+  - name: "catalog"
+    module: "platform-standards"
+    path: "services/catalog"
+    inputs: {}

--- a/examples/22-cli-module-update-ref/module/files/STANDARDS.md
+++ b/examples/22-cli-module-update-ref/module/files/STANDARDS.md
@@ -1,0 +1,3 @@
+# Platform Standards Module
+
+This fixture focuses on module ref bump behavior in `weaver.yaml`.


### PR DESCRIPTION
### Motivation
- Fill gaps in the examples/ coverage of the CLI surface defined in the PRD by adding red-test fixtures for discovery, inspection, module ref updates, and policy checks.
- Provide realistic, self-contained workspaces that demonstrate non-mutating inspection commands and `rw check` guardrails for Kubernetes and Terraform scenarios.
- Make it easier to drive TDD and CI validation by supplying before/after expectations for common operator workflows (`rw list`, `rw task list`, `rw describe`, `rw module update`, and `rw check`).

### Description
- Added five new example fixtures under `examples/`: `18-cli-list-and-task-list`, `19-cli-describe-resolved-config`, `20-check-k8s-ingress-annotations`, `21-check-terraform-ec2-tags`, and `22-cli-module-update-ref`, each with `module/`, `before/`, and `after/` layouts and local module sources (`../module`).
- Each fixture contains realistic content: app task definitions for discovery, `weaver.d/` include + overrides for resolved-config inspection, a non-compliant and compliant `k8s/ingress.yaml` for ingress annotation checks, a non-compliant and compliant `infra/main.tf` for EC2 tagging checks, and a module-ref bump example showing `ref: "v1"` -> `ref: "v2"`.
- All examples are authored as red tests (expected behaviors) and omit `weaver.module.yaml` when the module does not define inputs, following the example design rules.
- Files added include READMEs documenting how to run the scenario and the before/after fixtures that encode the expected workspace state.

### Testing
- Ran the repository test suite with `cargo test -q` but the run timed out in this environment and exited with code `124`, so automated tests were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cd458aa5f883309ea770cef463d62c)