### PR TITLE
test(examples): detect stage mismatches in example suite

### DIFF
--- a/crates/cli/tests/examples_suite.rs
+++ b/crates/cli/tests/examples_suite.rs
@@ -83,8 +83,19 @@ fn examples_apply_snapshot_suite() {
         let settings = merged_settings(&cfg, &name);
         let result = run_example(&example_dir, &settings);
 
-        if settings.stage == Stage::Implemented && !result.ok {
-            failures.push(format!("{name}: {}", result.details.join("; ")));
+        match (settings.stage, result.ok) {
+            (Stage::Implemented, false) => {
+                failures.push(format!(
+                    "{name} [implemented regressed]: {}",
+                    result.details.join("; ")
+                ));
+            }
+            (Stage::Pending, true) => {
+                failures.push(format!(
+                    "{name} [pending but passes — promote to `stage: implemented`]"
+                ));
+            }
+            _ => {}
         }
         results.push(result);
     }
@@ -93,7 +104,7 @@ fn examples_apply_snapshot_suite() {
 
     if !failures.is_empty() {
         panic!(
-            "Implemented examples regressed:\n{}",
+            "Stage mismatches detected:\n{}",
             failures
                 .into_iter()
                 .map(|line| format!("- {line}"))

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -9,13 +9,13 @@ examples:
   01-basic-static-files:
     stage: pending
   02-template-rendering:
-    stage: pending
+    stage: implemented
   03-mixed-files-and-templates:
-    stage: pending
+    stage: implemented
   04-multiple-apps:
-    stage: pending
+    stage: implemented
   05-nested-folders:
-    stage: pending
+    stage: implemented
   06-config-includes:
     stage: pending
   07-multiple-modules:
@@ -33,7 +33,7 @@ examples:
   13-plan-out-file:
     stage: pending
   14-run-task-with-args:
-    stage: pending
+    stage: implemented
   15-node-npm-ensures:
     stage: pending
   16-go-module-management:


### PR DESCRIPTION
## Summary
- Suite panics when pending example passes (stage drift).
- Promotes 02, 03, 04, 05, 14 → `stage: implemented` (regressions now hard-fail).
- 24 still-failing pending examples remain tolerated; report at `target/examples-compat-report.md`.

Note: overlaps with PR #14 commits (fcbac61, 4d6949e) — only `1b9f40d` is new here. Consider rebasing onto PR #14's branch or landing PR #14 first.

## Test plan
- [x] `cargo test --test examples_suite` green
- [ ] Manually confirm a passing example flipped to pending triggers panic