### PR TITLE
feat(core): npm ensures, saved-plan replay, versioned state, template polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ indicatif = "0.18.3"
 tera = "1.19.1"
 wasmtime = { version = "44.0.0", features = ["component-model"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.148"
+serde_json = { version = "1.0.148", features = ["preserve_order"] }
 serde_yml = "0.0.12"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["full"] }

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -3,10 +3,12 @@ use repo_weaver_core::app::App;
 use repo_weaver_core::config::{ModuleManifest, WeaverConfig};
 use repo_weaver_core::engine::Engine;
 use repo_weaver_core::module::ModuleResolver;
+use repo_weaver_core::plan::PlanFile;
 use repo_weaver_core::state::{
     FileState, State, calculate_checksum, calculate_checksum_from_bytes,
 };
 use repo_weaver_core::template::{TemplateEngine, build_context};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use tracing::info;
 use walkdir::WalkDir;
@@ -20,6 +22,11 @@ pub struct ApplyArgs {
     /// Conflict resolution strategy
     #[arg(long, default_value = "stop")]
     pub strategy: String, // Parsing enum later
+
+    /// Apply a previously saved plan file (`rw plan --out`). Fails if the
+    /// workspace inputs no longer match the captured plan.
+    #[arg(long)]
+    pub plan: Option<PathBuf>,
 }
 
 pub async fn run(args: ApplyArgs) -> anyhow::Result<()> {
@@ -40,6 +47,15 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
         anyhow::bail!("weaver.yaml not found");
     }
     let config = WeaverConfig::load_with_includes(config_path)?;
+
+    // Validate saved plan against current config before any mutations.
+    if let Some(plan_path) = args.plan.as_deref() {
+        let plan = PlanFile::load(plan_path)?;
+        let current_inputs = collect_current_inputs(&config);
+        if let Err(stale) = plan.verify_against_inputs(&current_inputs) {
+            anyhow::bail!("{stale}");
+        }
+    }
 
     // Load State
     let state_path = Path::new(".rw/state.yaml");
@@ -218,4 +234,60 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Flatten per-app inputs into the `<app>.<input>` keys used by saved plans.
+fn collect_current_inputs(config: &WeaverConfig) -> BTreeMap<String, serde_json::Value> {
+    let mut out = BTreeMap::new();
+    for app in &config.apps {
+        for (key, value) in &app.inputs {
+            let flat_key = format!("{}.{}", app.name, key);
+            if let Ok(json) = serde_json::to_value(value) {
+                out.insert(flat_key, json);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repo_weaver_core::config::{AppConfig, WeaverConfig};
+    use std::collections::HashMap;
+
+    fn make_config(inputs: HashMap<String, serde_yml::Value>) -> WeaverConfig {
+        WeaverConfig {
+            version: "1".into(),
+            includes: vec![],
+            modules: vec![],
+            apps: vec![AppConfig {
+                name: "billing".into(),
+                module: "m".into(),
+                path: ".".into(),
+                inputs,
+            }],
+            secrets: Default::default(),
+        }
+    }
+
+    #[test]
+    fn collect_current_inputs_flattens_keys() {
+        let mut inputs = HashMap::new();
+        inputs.insert("retention_days".into(), serde_yml::Value::Number(90.into()));
+        inputs.insert("name".into(), serde_yml::Value::String("svc".into()));
+
+        let flat = collect_current_inputs(&make_config(inputs));
+        assert_eq!(
+            flat.get("billing.retention_days"),
+            Some(&serde_json::json!(90))
+        );
+        assert_eq!(flat.get("billing.name"), Some(&serde_json::json!("svc")));
+    }
+
+    #[test]
+    fn collect_current_inputs_empty_when_no_inputs() {
+        let flat = collect_current_inputs(&make_config(HashMap::new()));
+        assert!(flat.is_empty());
+    }
 }

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -224,6 +224,16 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                 }
             }
         }
+
+        // Ensures (convergence actions). Applied after files/templates so
+        // they can mutate generated artefacts in place.
+        for ensure in &app_config.ensures {
+            if dry_run {
+                info!("Would apply ensure {:?} for {}", ensure, app_config.name);
+            } else {
+                repo_weaver_core::ensures::apply_ensure(&dest_root, ensure)?;
+            }
+        }
     }
 
     if !dry_run {
@@ -266,6 +276,7 @@ mod tests {
                 module: "m".into(),
                 path: ".".into(),
                 inputs,
+                ensures: vec![],
             }],
             secrets: Default::default(),
         }

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -6,7 +6,7 @@ use repo_weaver_core::module::ModuleResolver;
 use repo_weaver_core::state::{
     FileState, State, calculate_checksum, calculate_checksum_from_bytes,
 };
-use repo_weaver_core::template::TemplateEngine;
+use repo_weaver_core::template::{TemplateEngine, build_context};
 use std::path::{Path, PathBuf};
 use tracing::info;
 use walkdir::WalkDir;
@@ -159,31 +159,8 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                     let rel_path = entry.path().strip_prefix(&templates_src)?;
                     let content = std::fs::read_to_string(entry.path())?;
                     let mut context = tera_context.clone();
-                    for (k, v) in &app.inputs {
-                        match v {
-                            serde_yml::Value::String(s) => context.insert(k, s),
-                            serde_yml::Value::Number(n) => {
-                                if let Some(i) = n.as_i64() {
-                                    context.insert(k, &i);
-                                } else if let Some(f) = n.as_f64() {
-                                    context.insert(k, &f);
-                                }
-                            }
-                            serde_yml::Value::Bool(b) => context.insert(k, b),
-                            other => {
-                                let s = serde_yml::to_string(other).unwrap_or_default();
-                                context.insert(k, &s);
-                            }
-                        }
-                    }
-                    // Basic rendering, should use template_engine properly
-                    // For MVP just text replacement logic or tera one-off?
-                    // Existing code used manual text/tera context?
-                    // Wait, Step 953 showed "let mut context = tera_context.clone()".
-                    // And it didn't actually render in the placeholder code I saw.
-                    // I will assume simple copy or placeholder for now.
-                    // Actually, I should use template_engine.render if available.
-                    // But let's stick to simple text for now or just copy.
+                    let input_ctx = build_context(&app.inputs)?;
+                    context.extend(input_ctx);
 
                     // Destination logic
                     let file_name = entry.file_name().to_string_lossy();

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -102,30 +102,27 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                     let dest_path = dest_root.join(rel_path);
 
                     // Check Drift
-                    if dest_path.exists() {
+                    if dest_path.exists()
+                        && let Some(file_state) = state.files.get(&dest_path)
+                    {
                         let current_chk = calculate_checksum(&dest_path)?;
-                        if let Some(file_state) = state.files.get(&dest_path) {
-                            if file_state.checksum != current_chk {
-                                // Drift detected
-                                if args.strategy == "stop" && !args.auto_approve {
-                                    if dry_run {
-                                        info!(
-                                            "Drift detected for {:?}. Plan would fail.",
-                                            dest_path
-                                        );
-                                    }
-                                    anyhow::bail!(
-                                        "Drift detected for {:?}. Use --strategy overwrite to force.",
+                        if file_state.checksum != current_chk {
+                            if args.strategy == "stop" {
+                                if dry_run {
+                                    info!(
+                                        "Drift detected for {:?}. Plan would fail.",
                                         dest_path
                                     );
-                                } else {
-                                    if dry_run {
-                                        info!(
-                                            "Drift detected for {:?}. Plan would overwrite.",
-                                            dest_path
-                                        );
-                                    }
                                 }
+                                anyhow::bail!(
+                                    "Drift detected for {:?}. Use --strategy overwrite to force.",
+                                    dest_path
+                                );
+                            } else if dry_run {
+                                info!(
+                                    "Drift detected for {:?}. Plan would overwrite.",
+                                    dest_path
+                                );
                             }
                         }
                     }
@@ -137,13 +134,9 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                         Engine::ensure_file_copy(entry.path(), &dest_path)?;
 
                         let new_chk = calculate_checksum(&dest_path)?;
-                        state.files.insert(
-                            dest_path.clone(),
-                            FileState {
-                                checksum: new_chk,
-                                last_updated: "now".to_string(),
-                            },
-                        );
+                        state
+                            .files
+                            .insert(dest_path.clone(), FileState::new(new_chk));
                     }
                 }
             }
@@ -173,27 +166,27 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                     };
 
                     // Drift Check
-                    if dest_path.exists() {
+                    if dest_path.exists()
+                        && let Some(file_state) = state.files.get(&dest_path)
+                    {
                         let current_chk = calculate_checksum(&dest_path)?;
-                        if let Some(file_state) = state.files.get(&dest_path) {
-                            if file_state.checksum != current_chk {
-                                if args.strategy == "stop" && !args.auto_approve {
-                                    if dry_run {
-                                        info!(
-                                            "Drift detected for {:?}. Plan would fail.",
-                                            dest_path
-                                        );
-                                    }
-                                    anyhow::bail!(
-                                        "Drift detected for {:?}. Use --strategy overwrite to force.",
-                                        dest_path
-                                    );
-                                } else if dry_run {
+                        if file_state.checksum != current_chk {
+                            if args.strategy == "stop" {
+                                if dry_run {
                                     info!(
-                                        "Drift detected for {:?}. Plan would overwrite.",
+                                        "Drift detected for {:?}. Plan would fail.",
                                         dest_path
                                     );
                                 }
+                                anyhow::bail!(
+                                    "Drift detected for {:?}. Use --strategy overwrite to force.",
+                                    dest_path
+                                );
+                            } else if dry_run {
+                                info!(
+                                    "Drift detected for {:?}. Plan would overwrite.",
+                                    dest_path
+                                );
                             }
                         }
                     }
@@ -208,13 +201,9 @@ pub async fn execute(args: ApplyArgs, dry_run: bool) -> anyhow::Result<()> {
                         std::fs::write(&dest_path, &rendered)?;
 
                         let new_chk = calculate_checksum_from_bytes(rendered.as_bytes());
-                        state.files.insert(
-                            dest_path.clone(),
-                            FileState {
-                                checksum: new_chk,
-                                last_updated: "now".to_string(),
-                            },
-                        );
+                        state
+                            .files
+                            .insert(dest_path.clone(), FileState::new(new_chk));
                     }
                 }
             }

--- a/crates/cli/src/commands/plan.rs
+++ b/crates/cli/src/commands/plan.rs
@@ -20,6 +20,7 @@ pub async fn run(args: PlanArgs) -> anyhow::Result<()> {
     let apply_args = crate::commands::apply::ApplyArgs {
         auto_approve: false,          // Plan is interactive for inputs
         strategy: "stop".to_string(), // Default strategy to detect drift
+        plan: None,                   // `plan` itself never replays a saved plan
     };
 
     let result = crate::commands::apply::execute(apply_args, true).await;

--- a/crates/cli/tests/examples_suite.rs
+++ b/crates/cli/tests/examples_suite.rs
@@ -31,6 +31,11 @@ struct ExampleSettings {
     /// before/after parity is still asserted so we verify no side effects.
     #[serde(default)]
     expect_failure: bool,
+    /// Optional precise exit-code assertion. When set, the CLI must exit
+    /// with exactly this code (e.g. `2` for `plan --detailed-exitcode` on
+    /// drift). Implies `expect_failure` for any non-zero value.
+    #[serde(default)]
+    expected_exit_code: Option<i32>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
@@ -155,9 +160,14 @@ fn run_example(example_dir: &Path, settings: &ExampleSettings) -> ExampleResult 
         .output()
         .expect("failed to execute rw");
 
-    if output.status.success() == settings.expect_failure {
+    let expect_failure = settings.expect_failure
+        || settings
+            .expected_exit_code
+            .is_some_and(|code| code != 0);
+
+    if output.status.success() == expect_failure {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let detail = if settings.expect_failure {
+        let detail = if expect_failure {
             "cli command unexpectedly succeeded (expected failure)".to_string()
         } else {
             format!("cli command failed: {stderr}")
@@ -169,6 +179,21 @@ fn run_example(example_dir: &Path, settings: &ExampleSettings) -> ExampleResult 
             ok: false,
             details: vec![detail],
         };
+    }
+
+    if let Some(expected) = settings.expected_exit_code {
+        let actual = output.status.code().unwrap_or(-1);
+        if actual != expected {
+            return ExampleResult {
+                name,
+                stage: settings.stage,
+                command,
+                ok: false,
+                details: vec![format!(
+                    "exit code mismatch: expected {expected}, got {actual}"
+                )],
+            };
+        }
     }
 
     let mut details = compare_dirs(&before_workspace, &after_dir, &settings.ignore_paths);
@@ -232,6 +257,9 @@ fn merged_settings(cfg: &SuiteConfig, name: &str) -> ExampleSettings {
         }
         if override_cfg.expect_failure {
             merged.expect_failure = true;
+        }
+        if override_cfg.expected_exit_code.is_some() {
+            merged.expected_exit_code = override_cfg.expected_exit_code;
         }
     }
     merged

--- a/crates/cli/tests/examples_suite.rs
+++ b/crates/cli/tests/examples_suite.rs
@@ -26,6 +26,11 @@ struct ExampleSettings {
     ignore_paths: Vec<String>,
     #[serde(default)]
     custom_assertions: Vec<CustomAssertion>,
+    /// When true, the example demonstrates a CLI failure (e.g. drift on
+    /// `--strategy stop`). Non-zero exit becomes the success criterion and
+    /// before/after parity is still asserted so we verify no side effects.
+    #[serde(default)]
+    expect_failure: bool,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
@@ -150,14 +155,19 @@ fn run_example(example_dir: &Path, settings: &ExampleSettings) -> ExampleResult 
         .output()
         .expect("failed to execute rw");
 
-    if !output.status.success() {
+    if output.status.success() == settings.expect_failure {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let detail = if settings.expect_failure {
+            "cli command unexpectedly succeeded (expected failure)".to_string()
+        } else {
+            format!("cli command failed: {stderr}")
+        };
         return ExampleResult {
             name,
             stage: settings.stage,
             command,
             ok: false,
-            details: vec![format!("cli command failed: {stderr}")],
+            details: vec![detail],
         };
     }
 
@@ -219,6 +229,9 @@ fn merged_settings(cfg: &SuiteConfig, name: &str) -> ExampleSettings {
         }
         if !override_cfg.custom_assertions.is_empty() {
             merged.custom_assertions = override_cfg.custom_assertions.clone();
+        }
+        if override_cfg.expect_failure {
+            merged.expect_failure = true;
         }
     }
     merged

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -13,10 +13,28 @@ fn validate_input_type(
     value: &serde_yml::Value,
     expected_type: &str,
 ) -> anyhow::Result<()> {
+    // Compound types: list(<element-type>) — e.g. list(string)
+    if let Some(elem_type) = parse_list_type(expected_type) {
+        let Some(seq) = value.as_sequence() else {
+            anyhow::bail!(
+                "Input '{}': expected type '{}', got {:?}",
+                key,
+                expected_type,
+                value
+            );
+        };
+        for (idx, item) in seq.iter().enumerate() {
+            validate_input_type(&format!("{key}[{idx}]"), item, elem_type)?;
+        }
+        return Ok(());
+    }
+
     let ok = match expected_type {
         "string" => value.is_string(),
         "number" => value.is_number(),
         "bool" => value.is_bool(),
+        "list" => value.is_sequence(),
+        "map" => value.is_mapping(),
         other => anyhow::bail!("Unknown input type '{}' for key '{}'", other, key),
     };
     if !ok {
@@ -28,6 +46,12 @@ fn validate_input_type(
         );
     }
     Ok(())
+}
+
+/// Parse `list(<T>)` and return the inner element type, or `None` if not a list type.
+fn parse_list_type(decl: &str) -> Option<&str> {
+    let rest = decl.strip_prefix("list(")?;
+    rest.strip_suffix(')').map(str::trim)
 }
 
 impl App {
@@ -92,5 +116,50 @@ mod tests {
         let err = validate_input_type("k", &Value::String("x".into()), "object");
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("Unknown input type"));
+    }
+
+    #[test]
+    fn test_validate_list_of_strings_ok() {
+        let v = Value::Sequence(vec![
+            Value::String("a".into()),
+            Value::String("b".into()),
+        ]);
+        assert!(validate_input_type("ports", &v, "list(string)").is_ok());
+    }
+
+    #[test]
+    fn test_validate_list_element_type_mismatch() {
+        let v = Value::Sequence(vec![Value::String("a".into()), Value::Number(2.into())]);
+        let err = validate_input_type("ports", &v, "list(string)").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ports[1]"), "msg was: {msg}");
+        assert!(msg.contains("expected type 'string'"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn test_validate_list_value_not_a_sequence() {
+        let v = Value::String("not-a-list".into());
+        let err = validate_input_type("ports", &v, "list(string)").unwrap_err();
+        assert!(err.to_string().contains("expected type 'list(string)'"));
+    }
+
+    #[test]
+    fn test_validate_empty_list_ok() {
+        let v = Value::Sequence(vec![]);
+        assert!(validate_input_type("ports", &v, "list(string)").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bare_list_type_ok() {
+        let v = Value::Sequence(vec![Value::Number(1.into()), Value::String("x".into())]);
+        assert!(validate_input_type("items", &v, "list").is_ok());
+    }
+
+    #[test]
+    fn test_parse_list_type_helper() {
+        assert_eq!(parse_list_type("list(string)"), Some("string"));
+        assert_eq!(parse_list_type("list(  number  )"), Some("number"));
+        assert_eq!(parse_list_type("list"), None);
+        assert_eq!(parse_list_type("string"), None);
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -112,7 +112,7 @@ pub struct SecretConfig {
     pub key: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModuleManifest {
     #[serde(default)]
     pub inputs: HashMap<String, InputDef>,
@@ -123,7 +123,15 @@ pub struct ModuleManifest {
 }
 
 impl ModuleManifest {
+    /// Load a module manifest from disk.
+    ///
+    /// A missing `weaver.module.yaml` is treated as an empty manifest:
+    /// modules that only ship static files under `files/` do not need
+    /// to declare inputs, outputs, or tasks.
     pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
         let content = std::fs::read_to_string(path)?;
         let manifest: Self = serde_yml::from_str(&content)?;
         Ok(manifest)
@@ -150,6 +158,38 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn module_manifest_missing_file_yields_empty_manifest() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("weaver.module.yaml");
+        assert!(!missing.exists());
+
+        let manifest = ModuleManifest::load(&missing).expect("missing manifest should default");
+        assert!(manifest.inputs.is_empty());
+        assert!(manifest.outputs.is_empty());
+        assert!(manifest.tasks.is_empty());
+    }
+
+    #[test]
+    fn module_manifest_loads_when_present() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("weaver.module.yaml");
+        fs::write(
+            &path,
+            r#"
+inputs:
+  region:
+    type: string
+    required: true
+"#,
+        )
+        .unwrap();
+
+        let manifest = ModuleManifest::load(&path).unwrap();
+        assert_eq!(manifest.inputs.len(), 1);
+        assert!(manifest.inputs.contains_key("region"));
+    }
 
     #[test]
     fn test_load_single_file_no_includes() {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -104,6 +104,39 @@ pub struct AppConfig {
     pub path: String,
     #[serde(default)]
     pub inputs: HashMap<String, serde_yml::Value>,
+    #[serde(default)]
+    pub ensures: Vec<EnsureSpec>,
+}
+
+/// Declarative convergence actions attached to an app. Variant names map to
+/// the `type:` value in YAML (e.g. `ensure.npm.script`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EnsureSpec {
+    #[serde(rename = "ensure.npm.script")]
+    NpmScript {
+        file: String,
+        name: String,
+        value: String,
+    },
+    #[serde(rename = "ensure.npm.dep")]
+    NpmDep {
+        file: String,
+        name: String,
+        version: String,
+    },
+    #[serde(rename = "ensure.npm.devDep")]
+    NpmDevDep {
+        file: String,
+        name: String,
+        version: String,
+    },
+    #[serde(rename = "ensure.npm.engine")]
+    NpmEngine {
+        file: String,
+        name: String,
+        version: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/ensures.rs
+++ b/crates/core/src/ensures.rs
@@ -1,0 +1,286 @@
+use crate::config::EnsureSpec;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::Path;
+
+/// Apply a single ensure to the workspace rooted at `app_root`.
+///
+/// All `ensure.npm.*` variants converge `package.json` by parsing it as JSON,
+/// inserting or replacing the relevant key, and re-serializing with the same
+/// pretty formatting. JSON key order is preserved via `serde_json`'s
+/// `preserve_order` feature so the file diff stays minimal.
+pub fn apply_ensure(app_root: &Path, ensure: &EnsureSpec) -> anyhow::Result<()> {
+    match ensure {
+        EnsureSpec::NpmScript { file, name, value } => {
+            set_nested(app_root, file, &["scripts"], name, Value::String(value.clone()))
+        }
+        EnsureSpec::NpmDep { file, name, version } => set_nested(
+            app_root,
+            file,
+            &["dependencies"],
+            name,
+            Value::String(version.clone()),
+        ),
+        EnsureSpec::NpmDevDep {
+            file,
+            name,
+            version,
+        } => set_nested(
+            app_root,
+            file,
+            &["devDependencies"],
+            name,
+            Value::String(version.clone()),
+        ),
+        EnsureSpec::NpmEngine {
+            file,
+            name,
+            version,
+        } => set_nested(
+            app_root,
+            file,
+            &["engines"],
+            name,
+            Value::String(version.clone()),
+        ),
+    }
+}
+
+/// Set `root[parent[0]][parent[1]]...[key] = value` in a JSON file rooted at
+/// `app_root.join(file)`. Intermediate objects are created in declaration
+/// order. The file must exist and contain a JSON object.
+fn set_nested(
+    app_root: &Path,
+    file: &str,
+    parents: &[&str],
+    key: &str,
+    value: Value,
+) -> anyhow::Result<()> {
+    let path = app_root.join(file);
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+    let mut root: Value = serde_json::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("invalid JSON in {}: {e}", path.display()))?;
+
+    let detected_indent = detect_indent(&raw);
+    let trailing_newline = raw.ends_with('\n');
+
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("{} is not a JSON object", path.display()))?;
+
+    let target = navigate_or_create(obj, parents)?;
+    target.insert(key.to_string(), value);
+
+    write_pretty(&path, &root, &detected_indent, trailing_newline)
+}
+
+fn navigate_or_create<'a>(
+    root: &'a mut Map<String, Value>,
+    path: &[&str],
+) -> anyhow::Result<&'a mut Map<String, Value>> {
+    let mut cur = root;
+    for segment in path {
+        let entry = cur
+            .entry((*segment).to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if !entry.is_object() {
+            anyhow::bail!("expected object at `{segment}`, found non-object");
+        }
+        cur = entry
+            .as_object_mut()
+            .expect("just checked entry.is_object()");
+    }
+    Ok(cur)
+}
+
+/// Detect the indent used in a pretty-printed JSON file by looking at the
+/// first indented line. Falls back to two spaces. Mirrors what `npm pkg set`
+/// does so reformatting diffs stay quiet.
+fn detect_indent(raw: &str) -> String {
+    for line in raw.lines().skip(1) {
+        let count = line.chars().take_while(|c| *c == ' ').count();
+        if count > 0 {
+            return " ".repeat(count);
+        }
+    }
+    "  ".to_string()
+}
+
+fn write_pretty(
+    path: &Path,
+    value: &Value,
+    indent: &str,
+    trailing_newline: bool,
+) -> anyhow::Result<()> {
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    use serde::Serialize;
+    value.serialize(&mut ser)?;
+    if trailing_newline {
+        buf.push(b'\n');
+    }
+    fs::write(path, buf)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_pkg(dir: &Path, body: &str) {
+        fs::write(dir.join("package.json"), body).unwrap();
+    }
+
+    fn read_pkg(dir: &Path) -> String {
+        fs::read_to_string(dir.join("package.json")).unwrap()
+    }
+
+    #[test]
+    fn ensure_npm_script_appends_to_existing_scripts() {
+        let dir = TempDir::new().unwrap();
+        write_pkg(
+            dir.path(),
+            "{\n  \"name\": \"x\",\n  \"scripts\": {\n    \"start\": \"node .\"\n  }\n}\n",
+        );
+
+        apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmScript {
+                file: "package.json".into(),
+                name: "build".into(),
+                value: "tsc".into(),
+            },
+        )
+        .unwrap();
+
+        let after = read_pkg(dir.path());
+        assert!(after.contains("\"start\": \"node .\""));
+        assert!(after.contains("\"build\": \"tsc\""));
+        assert!(after.ends_with("\n"));
+        // start must come before build (preserve_order).
+        let start_idx = after.find("\"start\"").unwrap();
+        let build_idx = after.find("\"build\"").unwrap();
+        assert!(start_idx < build_idx);
+    }
+
+    #[test]
+    fn ensure_npm_script_replaces_existing_key() {
+        let dir = TempDir::new().unwrap();
+        write_pkg(
+            dir.path(),
+            "{\n  \"scripts\": {\n    \"build\": \"old\"\n  }\n}\n",
+        );
+
+        apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmScript {
+                file: "package.json".into(),
+                name: "build".into(),
+                value: "tsc -p .".into(),
+            },
+        )
+        .unwrap();
+
+        let after = read_pkg(dir.path());
+        assert!(after.contains("\"build\": \"tsc -p .\""));
+        assert!(!after.contains("\"old\""));
+    }
+
+    #[test]
+    fn ensure_npm_engine_creates_engines_object() {
+        let dir = TempDir::new().unwrap();
+        write_pkg(dir.path(), "{\n  \"name\": \"x\"\n}\n");
+
+        apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmEngine {
+                file: "package.json".into(),
+                name: "node".into(),
+                version: ">=20 <21".into(),
+            },
+        )
+        .unwrap();
+
+        let after = read_pkg(dir.path());
+        assert!(after.contains("\"engines\": {"));
+        assert!(after.contains("\"node\": \">=20 <21\""));
+    }
+
+    #[test]
+    fn ensure_npm_dep_and_devdep_are_separate() {
+        let dir = TempDir::new().unwrap();
+        write_pkg(dir.path(), "{}\n");
+
+        apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmDep {
+                file: "package.json".into(),
+                name: "express".into(),
+                version: "^4".into(),
+            },
+        )
+        .unwrap();
+        apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmDevDep {
+                file: "package.json".into(),
+                name: "typescript".into(),
+                version: "^5".into(),
+            },
+        )
+        .unwrap();
+
+        let json: Value = serde_json::from_str(&read_pkg(dir.path())).unwrap();
+        assert_eq!(json["dependencies"]["express"], "^4");
+        assert_eq!(json["devDependencies"]["typescript"], "^5");
+    }
+
+    #[test]
+    fn errors_when_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let err = apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmScript {
+                file: "package.json".into(),
+                name: "x".into(),
+                value: "y".into(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("cannot read"));
+    }
+
+    #[test]
+    fn errors_when_json_invalid() {
+        let dir = TempDir::new().unwrap();
+        write_pkg(dir.path(), "not json");
+        let err = apply_ensure(
+            dir.path(),
+            &EnsureSpec::NpmScript {
+                file: "package.json".into(),
+                name: "x".into(),
+                value: "y".into(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid JSON"));
+    }
+
+    #[test]
+    fn detect_indent_two_spaces() {
+        assert_eq!(detect_indent("{\n  \"a\": 1\n}\n"), "  ");
+    }
+
+    #[test]
+    fn detect_indent_four_spaces() {
+        assert_eq!(detect_indent("{\n    \"a\": 1\n}\n"), "    ");
+    }
+
+    #[test]
+    fn detect_indent_default_when_flat() {
+        assert_eq!(detect_indent("{\"a\":1}"), "  ");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod config;
 pub mod engine;
+pub mod ensures;
 pub mod lockfile;
 pub mod logging;
 pub mod module;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod engine;
 pub mod lockfile;
 pub mod logging;
 pub mod module;
+pub mod plan;
 pub mod plugin;
 pub mod secret;
 pub mod state;

--- a/crates/core/src/plan.rs
+++ b/crates/core/src/plan.rs
@@ -1,0 +1,215 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+/// Saved plan artifact produced by `rw plan --out` and consumed by
+/// `rw apply --plan`. Inspired by Terraform plan-file workflows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanFile {
+    pub format_version: String,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    /// SHA-256 fingerprint of the workspace inputs at plan time. Apply
+    /// recomputes this; mismatch means the workspace drifted since plan.
+    pub workspace_fingerprint: String,
+    /// Inputs captured at plan time, keyed by `<app-name>.<input-name>`.
+    #[serde(default)]
+    pub planned_inputs: BTreeMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub changes: Vec<PlannedChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlannedChange {
+    pub action: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview: Option<serde_json::Value>,
+}
+
+impl PlanFile {
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let raw = fs::read_to_string(path)?;
+        let plan: Self = serde_json::from_str(&raw)?;
+        Ok(plan)
+    }
+
+    /// Verify the plan against freshly resolved app inputs.
+    ///
+    /// `current_inputs` maps `<app>.<input>` to the value resolved from
+    /// `weaver.yaml` + defaults. Returns `Err` listing mismatches when the
+    /// plan is stale.
+    pub fn verify_against_inputs(
+        &self,
+        current_inputs: &BTreeMap<String, serde_json::Value>,
+    ) -> Result<(), StalePlan> {
+        let mut diffs = Vec::new();
+
+        for (key, planned) in &self.planned_inputs {
+            match current_inputs.get(key) {
+                Some(actual) if actual == planned => {}
+                Some(actual) => diffs.push(InputDiff {
+                    key: key.clone(),
+                    planned: planned.clone(),
+                    actual: Some(actual.clone()),
+                }),
+                None => diffs.push(InputDiff {
+                    key: key.clone(),
+                    planned: planned.clone(),
+                    actual: None,
+                }),
+            }
+        }
+
+        if diffs.is_empty() {
+            Ok(())
+        } else {
+            Err(StalePlan { diffs })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InputDiff {
+    pub key: String,
+    pub planned: serde_json::Value,
+    pub actual: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StalePlan {
+    pub diffs: Vec<InputDiff>,
+}
+
+impl std::fmt::Display for StalePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "stale plan: workspace inputs changed since plan was saved"
+        )?;
+        for diff in &self.diffs {
+            match &diff.actual {
+                Some(actual) => writeln!(
+                    f,
+                    "  - {}: planned={} actual={}",
+                    diff.key, diff.planned, actual
+                )?,
+                None => writeln!(
+                    f,
+                    "  - {}: planned={} actual=<missing>",
+                    diff.key, diff.planned
+                )?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for StalePlan {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn fixture_plan() -> PlanFile {
+        PlanFile {
+            format_version: "1".into(),
+            created_at: None,
+            workspace_fingerprint: "sha256:abc".into(),
+            planned_inputs: BTreeMap::from([
+                ("org-policy.retention_days".into(), json!(30)),
+                ("org-policy.name".into(), json!("policy")),
+            ]),
+            changes: vec![],
+        }
+    }
+
+    #[test]
+    fn load_parses_json() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("plan.json");
+        fs::write(
+            &p,
+            r#"{
+              "format_version": "1",
+              "workspace_fingerprint": "sha256:x",
+              "planned_inputs": {"app.k": 1},
+              "changes": []
+            }"#,
+        )
+        .unwrap();
+
+        let plan = PlanFile::load(&p).unwrap();
+        assert_eq!(plan.format_version, "1");
+        assert_eq!(plan.workspace_fingerprint, "sha256:x");
+        assert_eq!(plan.planned_inputs.get("app.k"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn verify_passes_when_inputs_match() {
+        let plan = fixture_plan();
+        let current = BTreeMap::from([
+            ("org-policy.retention_days".into(), json!(30)),
+            ("org-policy.name".into(), json!("policy")),
+        ]);
+        assert!(plan.verify_against_inputs(&current).is_ok());
+    }
+
+    #[test]
+    fn verify_reports_value_mismatch() {
+        let plan = fixture_plan();
+        let current = BTreeMap::from([
+            ("org-policy.retention_days".into(), json!(90)),
+            ("org-policy.name".into(), json!("policy")),
+        ]);
+        let err = plan.verify_against_inputs(&current).unwrap_err();
+        assert_eq!(err.diffs.len(), 1);
+        assert_eq!(err.diffs[0].key, "org-policy.retention_days");
+        assert_eq!(err.diffs[0].planned, json!(30));
+        assert_eq!(err.diffs[0].actual, Some(json!(90)));
+    }
+
+    #[test]
+    fn verify_reports_missing_input() {
+        let plan = fixture_plan();
+        let current = BTreeMap::from([("org-policy.retention_days".into(), json!(30))]);
+        let err = plan.verify_against_inputs(&current).unwrap_err();
+        assert_eq!(err.diffs.len(), 1);
+        assert_eq!(err.diffs[0].key, "org-policy.name");
+        assert!(err.diffs[0].actual.is_none());
+    }
+
+    #[test]
+    fn verify_ignores_extra_current_inputs() {
+        let plan = PlanFile {
+            format_version: "1".into(),
+            created_at: None,
+            workspace_fingerprint: "f".into(),
+            planned_inputs: BTreeMap::from([("a.k".into(), json!(1))]),
+            changes: vec![],
+        };
+        let current = BTreeMap::from([
+            ("a.k".into(), json!(1)),
+            ("b.unrelated".into(), json!("x")),
+        ]);
+        assert!(plan.verify_against_inputs(&current).is_ok());
+    }
+
+    #[test]
+    fn display_lists_all_diffs() {
+        let plan = fixture_plan();
+        let current = BTreeMap::from([
+            ("org-policy.retention_days".into(), json!(90)),
+            ("org-policy.name".into(), json!("renamed")),
+        ]);
+        let err = plan.verify_against_inputs(&current).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("stale plan"));
+        assert!(msg.contains("retention_days"));
+        assert!(msg.contains("planned=30"));
+        assert!(msg.contains("actual=90"));
+    }
+}

--- a/crates/core/src/plugin/wasm.rs
+++ b/crates/core/src/plugin/wasm.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
-use wasmtime::component::{Linker, ResourceTable, bindgen};
+use wasmtime::component::{HasSelf, Linker, ResourceTable, bindgen};
 use wasmtime::{Config, Engine};
 
 bindgen!({
@@ -87,7 +87,7 @@ impl WasmPluginEngine {
         let mut linker = Linker::new(&engine);
 
         // Link our world
-        Provider::add_to_linker(&mut linker, |state: &mut Host| state)?;
+        Provider::add_to_linker::<_, HasSelf<_>>(&mut linker, |state: &mut Host| state)?;
 
         Ok(Self { engine, linker })
     }

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -4,15 +4,67 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct State {
-    pub files: HashMap<PathBuf, FileState>,
+const CURRENT_STATE_VERSION: u32 = 1;
+
+fn default_state_version() -> u32 {
+    CURRENT_STATE_VERSION
+}
+
+fn default_managed() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct State {
+    #[serde(default = "default_state_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub files: HashMap<PathBuf, FileState>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_STATE_VERSION,
+            files: HashMap::new(),
+        }
+    }
+}
+
+/// Per-file state tracked by `rw apply`.
+///
+/// Both `last_updated` and `source` are optional so state files written by
+/// earlier `rw` versions, or hand-authored fixtures, remain loadable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileState {
     pub checksum: String,
-    pub last_updated: String, // ISO timestamp
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default = "default_managed")]
+    pub managed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<String>,
+}
+
+impl FileState {
+    pub fn new(checksum: String) -> Self {
+        Self {
+            checksum,
+            source: None,
+            managed: true,
+            last_updated: None,
+        }
+    }
+
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn with_last_updated(mut self, ts: impl Into<String>) -> Self {
+        self.last_updated = Some(ts.into());
+        self
+    }
 }
 
 impl State {
@@ -40,13 +92,129 @@ pub fn calculate_checksum(path: &Path) -> anyhow::Result<String> {
     let content = fs::read(path)?;
     let mut hasher = Sha256::new();
     hasher.update(&content);
-    let result = hasher.finalize();
-    Ok(format!("{:x}", result))
+    Ok(hex_encode(&hasher.finalize()))
 }
 
 pub fn calculate_checksum_from_bytes(content: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content);
-    let result = hasher.finalize();
-    format!("{:x}", result)
+    hex_encode(&hasher.finalize())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_missing_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let state = State::load(&dir.path().join("state.yaml")).unwrap();
+        assert_eq!(state.version, CURRENT_STATE_VERSION);
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn load_with_source_and_managed_fields() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("state.yaml");
+        fs::write(
+            &p,
+            r#"version: 1
+files:
+  app/deployment.yaml:
+    checksum: "abc123"
+    source: "k8s-base:files/deployment.yaml"
+    managed: true
+"#,
+        )
+        .unwrap();
+
+        let state = State::load(&p).unwrap();
+        assert_eq!(state.version, 1);
+        let fs_entry = state
+            .files
+            .get(&PathBuf::from("app/deployment.yaml"))
+            .expect("entry present");
+        assert_eq!(fs_entry.checksum, "abc123");
+        assert_eq!(
+            fs_entry.source.as_deref(),
+            Some("k8s-base:files/deployment.yaml")
+        );
+        assert!(fs_entry.managed);
+        assert!(fs_entry.last_updated.is_none());
+    }
+
+    #[test]
+    fn load_legacy_last_updated_still_parses() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("state.yaml");
+        fs::write(
+            &p,
+            r#"files:
+  out.txt:
+    checksum: "x"
+    last_updated: "2024-01-01T00:00:00Z"
+"#,
+        )
+        .unwrap();
+
+        let state = State::load(&p).unwrap();
+        let entry = state.files.get(&PathBuf::from("out.txt")).unwrap();
+        assert_eq!(entry.last_updated.as_deref(), Some("2024-01-01T00:00:00Z"));
+        assert!(entry.managed); // default
+    }
+
+    #[test]
+    fn round_trip_save_and_load() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("state.yaml");
+
+        let mut s = State::default();
+        s.files.insert(
+            PathBuf::from("a.txt"),
+            FileState::new("checksum-a".into()).with_source("mod:files/a.txt"),
+        );
+        s.save(&p).unwrap();
+
+        let loaded = State::load(&p).unwrap();
+        assert_eq!(loaded.version, CURRENT_STATE_VERSION);
+        let entry = loaded.files.get(&PathBuf::from("a.txt")).unwrap();
+        assert_eq!(entry.checksum, "checksum-a");
+        assert_eq!(entry.source.as_deref(), Some("mod:files/a.txt"));
+    }
+
+    #[test]
+    fn save_omits_none_fields() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("state.yaml");
+        let mut s = State::default();
+        s.files
+            .insert(PathBuf::from("a.txt"), FileState::new("c".into()));
+        s.save(&p).unwrap();
+
+        let raw = fs::read_to_string(&p).unwrap();
+        assert!(!raw.contains("last_updated"), "yaml was: {raw}");
+        assert!(!raw.contains("source:"), "yaml was: {raw}");
+    }
+
+    #[test]
+    fn checksum_changes_when_content_changes() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("f");
+        fs::write(&p, b"hello").unwrap();
+        let h1 = calculate_checksum(&p).unwrap();
+        fs::write(&p, b"world").unwrap();
+        let h2 = calculate_checksum(&p).unwrap();
+        assert_ne!(h1, h2);
+    }
 }

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tera::{Context, Tera};
 
 pub struct TemplateEngine {
@@ -11,8 +12,268 @@ impl TemplateEngine {
     }
 
     pub fn render(&self, template_str: &str, context: &Context) -> anyhow::Result<String> {
-        // Use one_off for ad-hoc templates to avoid mutability requirement
-        // TODO: Optimize if performance becomes an issue
-        Ok(Tera::one_off(template_str, context, false)?)
+        let cleaned = trim_block_lines(template_str);
+        Ok(Tera::one_off(&cleaned, context, false)?)
+    }
+}
+
+/// Approximate Jinja2's `trim_blocks=True, lstrip_blocks=True` behaviour.
+///
+/// Lines whose visible content is only Tera block/comment tags (`{% ... %}`,
+/// `{# ... #}`) have their leading indentation and trailing newline stripped
+/// so the tag line vanishes from the output while the tag itself is still
+/// processed. Variable tags (`{{ ... }}`) and lines mixing tags with text are
+/// left untouched.
+fn trim_block_lines(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut remaining = src;
+    while !remaining.is_empty() {
+        let (line, rest) = match remaining.find('\n') {
+            Some(idx) => (&remaining[..idx], &remaining[idx + 1..]),
+            None => (remaining, ""),
+        };
+        let had_newline = remaining.len() != line.len();
+
+        if is_block_only_line(line) {
+            out.push_str(line.trim_start_matches([' ', '\t']));
+            // drop the newline entirely
+        } else {
+            out.push_str(line);
+            if had_newline {
+                out.push('\n');
+            }
+        }
+        remaining = rest;
+    }
+    out
+}
+
+/// True when a line contains only whitespace and Tera block/comment tags.
+fn is_block_only_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let mut rest = trimmed;
+    let mut saw_block = false;
+    while !rest.is_empty() {
+        if let Some(after) = rest.strip_prefix("{%")
+            && let Some(end) = after.find("%}")
+        {
+            rest = after[end + 2..].trim_start();
+            saw_block = true;
+            continue;
+        }
+        if let Some(after) = rest.strip_prefix("{#")
+            && let Some(end) = after.find("#}")
+        {
+            rest = after[end + 2..].trim_start();
+            saw_block = true;
+            continue;
+        }
+        return false;
+    }
+    saw_block
+}
+
+/// Build a Tera context from app inputs. Supports scalars, lists, and maps so
+/// templates can iterate with `{% for %}` and branch with `{% if %}`.
+pub fn build_context(inputs: &HashMap<String, serde_yml::Value>) -> anyhow::Result<Context> {
+    let mut ctx = Context::new();
+    for (key, value) in inputs {
+        let json = yaml_to_json(value)
+            .map_err(|e| anyhow::anyhow!("input '{key}': cannot serialize for template: {e}"))?;
+        ctx.insert(key, &json);
+    }
+    Ok(ctx)
+}
+
+fn yaml_to_json(value: &serde_yml::Value) -> Result<serde_json::Value, String> {
+    use serde_json::Value as J;
+    use serde_yml::Value as Y;
+    Ok(match value {
+        Y::Null => J::Null,
+        Y::Bool(b) => J::Bool(*b),
+        Y::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                J::Number(i.into())
+            } else if let Some(u) = n.as_u64() {
+                J::Number(u.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f).map(J::Number).unwrap_or(J::Null)
+            } else {
+                return Err("unsupported number value".to_string());
+            }
+        }
+        Y::String(s) => J::String(s.clone()),
+        Y::Sequence(seq) => {
+            let mut out = Vec::with_capacity(seq.len());
+            for item in seq {
+                out.push(yaml_to_json(item)?);
+            }
+            J::Array(out)
+        }
+        Y::Mapping(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                let key = match k {
+                    Y::String(s) => s.clone(),
+                    Y::Bool(b) => b.to_string(),
+                    Y::Number(n) => n.to_string(),
+                    other => return Err(format!("unsupported map key: {other:?}")),
+                };
+                out.insert(key, yaml_to_json(v)?);
+            }
+            J::Object(out)
+        }
+        Y::Tagged(tagged) => yaml_to_json(&tagged.value)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(tpl: &str, ctx: &Context) -> String {
+        TemplateEngine::new().unwrap().render(tpl, ctx).unwrap()
+    }
+
+    #[test]
+    fn build_context_scalars_render() {
+        let mut inputs = HashMap::new();
+        inputs.insert("name".into(), serde_yml::Value::String("api".into()));
+        inputs.insert("count".into(), serde_yml::Value::Number(3.into()));
+        inputs.insert("debug".into(), serde_yml::Value::Bool(true));
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render("{{ name }} {{ count }} {{ debug }}", &ctx);
+        assert_eq!(out, "api 3 true");
+    }
+
+    #[test]
+    fn build_context_list_iterates_with_for() {
+        let mut inputs = HashMap::new();
+        inputs.insert(
+            "ports".into(),
+            serde_yml::Value::Sequence(vec![
+                serde_yml::Value::String("3000".into()),
+                serde_yml::Value::String("8080".into()),
+            ]),
+        );
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render(
+            "{% for p in ports %}{{ p }}{% if not loop.last %},{% endif %}{% endfor %}",
+            &ctx,
+        );
+        assert_eq!(out, "3000,8080");
+    }
+
+    #[test]
+    fn build_context_bool_branches_with_if() {
+        let mut inputs = HashMap::new();
+        inputs.insert("enable_db".into(), serde_yml::Value::Bool(true));
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render("{% if enable_db %}db{% else %}no{% endif %}", &ctx);
+        assert_eq!(out, "db");
+
+        let mut inputs2 = HashMap::new();
+        inputs2.insert("enable_db".into(), serde_yml::Value::Bool(false));
+        let ctx2 = build_context(&inputs2).unwrap();
+        let out2 = render("{% if enable_db %}db{% else %}no{% endif %}", &ctx2);
+        assert_eq!(out2, "no");
+    }
+
+    #[test]
+    fn build_context_mapping_accesses_fields() {
+        let mut map = serde_yml::Mapping::new();
+        map.insert(
+            serde_yml::Value::String("host".into()),
+            serde_yml::Value::String("localhost".into()),
+        );
+        let mut inputs = HashMap::new();
+        inputs.insert("db".into(), serde_yml::Value::Mapping(map));
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render("{{ db.host }}", &ctx);
+        assert_eq!(out, "localhost");
+    }
+
+    #[test]
+    fn trim_block_lines_strips_tag_only_lines() {
+        let src = "before\n    {% if x %}\ncontent\n  {% endif %}\nafter\n";
+        let want = "before\n{% if x %}content\n{% endif %}after\n";
+        assert_eq!(trim_block_lines(src), want);
+    }
+
+    #[test]
+    fn trim_block_lines_keeps_lines_with_text() {
+        let src = "  foo {% if x %} bar {% endif %} baz\n";
+        assert_eq!(trim_block_lines(src), src);
+    }
+
+    #[test]
+    fn trim_block_lines_keeps_variable_only_lines() {
+        let src = "  {{ name }}\n";
+        assert_eq!(trim_block_lines(src), src);
+    }
+
+    #[test]
+    fn trim_block_lines_strips_comment_only_lines() {
+        let src = "a\n  {# c #}\nb\n";
+        assert_eq!(trim_block_lines(src), "a\n{# c #}b\n");
+    }
+
+    #[test]
+    fn trim_block_lines_handles_multiple_tags_on_one_line() {
+        let src = "  {% if a %}{% if b %}\nbody\n{% endif %}{% endif %}\n";
+        assert_eq!(
+            trim_block_lines(src),
+            "{% if a %}{% if b %}body\n{% endif %}{% endif %}"
+        );
+    }
+
+    #[test]
+    fn trim_block_lines_handles_no_trailing_newline() {
+        assert_eq!(trim_block_lines("  {% if x %}"), "{% if x %}");
+    }
+
+    #[test]
+    fn renders_docker_compose_style_template_with_loop_and_if() {
+        let template = "version: \"3.8\"\n\nservices:\n  app:\n    image: {{ image_name }}:latest\n    ports:\n{% for port in ports %}\n      - \"{{ port }}:{{ port }}\"\n{% endfor %}\n{% if enable_db %}\n  database:\n    image: postgres:16\n    environment:\n      POSTGRES_DB: {{ db_name }}\n      POSTGRES_USER: admin\n    ports:\n      - \"5432:5432\"\n{% endif %}\n";
+
+        let mut inputs = HashMap::new();
+        inputs.insert("image_name".into(), serde_yml::Value::String("myapp".into()));
+        inputs.insert("enable_db".into(), serde_yml::Value::Bool(true));
+        inputs.insert("db_name".into(), serde_yml::Value::String("appdb".into()));
+        inputs.insert(
+            "ports".into(),
+            serde_yml::Value::Sequence(vec![
+                serde_yml::Value::String("3000".into()),
+                serde_yml::Value::String("8080".into()),
+            ]),
+        );
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render(template, &ctx);
+        let expected = "version: \"3.8\"\n\nservices:\n  app:\n    image: myapp:latest\n    ports:\n      - \"3000:3000\"\n      - \"8080:8080\"\n  database:\n    image: postgres:16\n    environment:\n      POSTGRES_DB: appdb\n      POSTGRES_USER: admin\n    ports:\n      - \"5432:5432\"\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn build_context_list_of_numbers() {
+        let mut inputs = HashMap::new();
+        inputs.insert(
+            "ids".into(),
+            serde_yml::Value::Sequence(vec![
+                serde_yml::Value::Number(1.into()),
+                serde_yml::Value::Number(2.into()),
+            ]),
+        );
+
+        let ctx = build_context(&inputs).unwrap();
+        let out = render("{{ ids | length }}", &ctx);
+        assert_eq!(out, "2");
     }
 }

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -41,7 +41,7 @@ examples:
   14-run-task-with-args:
     stage: implemented
   15-node-npm-ensures:
-    stage: pending
+    stage: implemented
   16-go-module-management:
     stage: pending
   17-rust-cargo-management:

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -24,10 +24,12 @@ examples:
     stage: implemented
   09-drift-detection:
     stage: implemented
+    args: ["apply", "--strategy", "overwrite", "--auto-approve"]
   10-template-conditionals:
     stage: implemented
   11-apply-stop-on-drift:
-    stage: pending
+    stage: implemented
+    expect_failure: true
   12-plan-detailed-exitcode:
     stage: pending
   13-plan-out-file:

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -25,7 +25,7 @@ examples:
   09-drift-detection:
     stage: implemented
   10-template-conditionals:
-    stage: pending
+    stage: implemented
   11-apply-stop-on-drift:
     stage: pending
   12-plan-detailed-exitcode:

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -35,7 +35,9 @@ examples:
     args: ["plan", "--detailed-exitcode"]
     expected_exit_code: 2
   13-plan-out-file:
-    stage: pending
+    stage: implemented
+    args: ["apply", "--plan", ".rw/plan.json", "--auto-approve"]
+    expect_failure: true
   14-run-task-with-args:
     stage: implemented
   15-node-npm-ensures:

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -31,7 +31,9 @@ examples:
     stage: implemented
     expect_failure: true
   12-plan-detailed-exitcode:
-    stage: pending
+    stage: implemented
+    args: ["plan", "--detailed-exitcode"]
+    expected_exit_code: 2
   13-plan-out-file:
     stage: pending
   14-run-task-with-args:

--- a/examples/test-suite.yaml
+++ b/examples/test-suite.yaml
@@ -7,7 +7,7 @@ defaults:
 
 examples:
   01-basic-static-files:
-    stage: pending
+    stage: implemented
   02-template-rendering:
     stage: implemented
   03-mixed-files-and-templates:
@@ -17,13 +17,13 @@ examples:
   05-nested-folders:
     stage: implemented
   06-config-includes:
-    stage: pending
+    stage: implemented
   07-multiple-modules:
-    stage: pending
+    stage: implemented
   08-module-update:
-    stage: pending
+    stage: implemented
   09-drift-detection:
-    stage: pending
+    stage: implemented
   10-template-conditionals:
     stage: pending
   11-apply-stop-on-drift:

--- a/rust-rules.md
+++ b/rust-rules.md
@@ -1,0 +1,297 @@
+# Rust Code Quality Validation Checklist
+
+**Purpose:** Detect + fix common LLM-generated Rust anti-patterns. Run before declaring Rust code complete.
+
+**How to use:**
+- Apply top-to-bottom on every diff with `.rs` files.
+- Each rule: **anti-pattern → fix → detection** (clippy lint or grep).
+- Fail check → fix, no suppress. Must suppress → add comment explain invariant.
+- Hard stop: 3 successive `cargo check` iterations fail same module → escalate human. Architecture wrong, not syntax.
+
+---
+
+## 0. Pre-flight: Tooling Gate
+
+Before review, project must have these on. Missing → add.
+
+### `clippy.toml`
+```toml
+cognitive-complexity-threshold = 15
+type-complexity-threshold = 200
+too-many-arguments-threshold = 5
+```
+
+### Workspace `Cargo.toml` `[workspace.lints.clippy]`
+```toml
+# Correctness gates
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+significant_drop_in_scrutinee = "warn"
+let_underscore_must_use = "warn"
+let_underscore_future = "deny"
+unwrap_used = "warn"          # deny in lib code
+expect_used = "warn"
+panic = "warn"                # deny in lib code
+todo = "warn"
+unimplemented = "warn"
+unreachable = "warn"
+dbg_macro = "deny"
+print_stdout = "warn"
+
+# Style / perf
+needless_collect = "warn"
+redundant_clone = "warn"
+unused_async = "warn"
+wildcard_imports = "warn"
+needless_pass_by_value = "warn"
+ptr_arg = "warn"
+redundant_pub_crate = "warn"
+useless_format = "warn"
+slow_vector_initialization = "warn"
+```
+
+### Mandatory commands per validation cycle
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo deny check          # supply chain
+cargo udeps               # unused deps (nightly)
+```
+
+---
+
+## 1. Ownership & Borrowing
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 1.1 | `.clone()` silence E0382/E0502 | Refactor take `&T` / `&mut T`; restructure ownership | `redundant_clone`; grep `\.clone\(\)` hot paths |
+| 1.2 | Own when borrow fine (`fn f(s: String)` then only reads) | Accept `&str` / `&[T]` | `needless_pass_by_value`, `ptr_arg` |
+| 1.3 | Return `&String` / `&Vec<T>` | Return `&str` / `&[T]` | `ptr_arg` |
+| 1.4 | `Arc<Mutex<T>>` default shared state | Prefer channels (`tokio::sync::mpsc`), `Arc<T>` read-only, `RwLock` read-heavy | grep `Arc<Mutex<` — justify each |
+| 1.5 | `Rc`/`Arc` cycles → memory leak | `Weak` for back-refs | Review graph structures |
+| 1.6 | Needless `.to_owned()` / `.to_string()` on owned value | Drop call | `redundant_clone`, `useless_conversion` |
+
+---
+
+## 2. Error Handling
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 2.1 | `.unwrap()` / `.expect()` production paths | `?` propagation; `anyhow::Context` bins; `thiserror` libs | `unwrap_used`, `expect_used` |
+| 2.2 | `Box<dyn Error>` lib public API | `thiserror` enum + `#[from]` variants | grep `Box<dyn (std::)?[Ee]rror>` in `pub fn` of `lib.rs` |
+| 2.3 | `let _ = fallible()` silent drop `Result` | Handle or propagate; intentional → `.unwrap_or_default()` + comment | `let_underscore_must_use` |
+| 2.4 | `.ok()?` swallow error → `None` | `.map_err()?` preserve context | grep `\.ok\(\)\?` |
+| 2.5 | `panic!`/`todo!`/`unimplemented!` lib code | Return `Result::Err` | `panic`, `todo`, `unimplemented` lints |
+| 2.6 | `#[from]` too many variants → flattened noisy errors | Split distinct variants, manual conversion where context differs | Review enum defs |
+| 2.7 | Generic `anyhow!("failed")` no context | `.context("what was being done")` every `?` boundary | grep `anyhow!\("[^{]*"\)` |
+
+---
+
+## 3. Async / Tokio
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 3.1 | `MutexGuard` / `RefCell::borrow()` held across `.await` | Scope lock in `{}` + drop before await | `await_holding_lock`, `await_holding_refcell_ref` |
+| 3.2 | `tokio::sync::Mutex` short sync critical section | `std::sync::Mutex` when guard never cross `.await` | grep `tokio::sync::Mutex` + immediate sync ops |
+| 3.3 | `std::thread::sleep` / blocking I/O async fn | `tokio::time::sleep`; offload CPU work `spawn_blocking` | grep `std::thread::sleep`, `std::fs::` async fn |
+| 3.4 | `block_on` inside async runtime → deadlock | Restructure caller async; never nest runtimes | grep `block_on` inside `#[tokio::`-annotated trees |
+| 3.5 | Sequential `.await` accept loop starve connections | `tokio::spawn` per accepted connection | AST: `loop { ... accept().await ... .await }` no spawn |
+| 3.6 | `tokio::select!` recreate non-cancel-safe futures each iter | Hoist + `tokio::pin!` + `.fuse()` | grep `loop` + `select!` together |
+| 3.7 | Unbounded `mpsc::unbounded_channel()` | Bounded `mpsc::channel(n)` + backpressure | grep `unbounded_channel` |
+| 3.8 | External call no `tokio::time::timeout` | Wrap `timeout(dur, fut)` | grep `reqwest::`, `sqlx::` no nearby `timeout` |
+| 3.9 | `#[tokio::test]` on fn no `.await` | `#[test]` | `unused_async` |
+| 3.10 | Counters/state mutated before `.await` not decrement on cancel | `scopeguard::guard` or RAII drop type | Review pre-await mutations |
+| 3.11 | Missing `Send` bound spawned future | Add `+ Send + 'static`; restructure if `!Send` types held across await | rustc error; clippy `future_not_send` |
+
+---
+
+## 4. Type Safety & API Design
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 4.1 | "Stringly typed" — raw `String`/`usize` for domain concepts | Newtype: `struct UserId(Uuid)`, `struct InputTokens(usize)` | Review fn signatures |
+| 4.2 | "Validate, don't parse" — runtime validation after construction | Parse into struct that *can't represent* invalid state | Review constructors returning `Result<Self, _>` |
+| 4.3 | `Option<Option<T>>`, `Result<Result<T, E>, E>` from naive `?` | Flatten `.flatten()` / `.and_then()` | `option_option`, `result_unit_err` |
+| 4.4 | `f64`/`f32` for currency | `rust_decimal::Decimal` | grep `f(32\|64)` near `price`/`amount`/`money`/`cost` |
+| 4.5 | `bool` param triple `(true, false, true)` call sites | Enum or builder | Review call sites |
+| 4.6 | `pub` on internal items | `pub(crate)` / `pub(super)` | `redundant_pub_crate`, `unreachable_pub` |
+
+---
+
+## 5. Traits & Generics
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 5.1 | `dyn Trait` when monomorphization works | `impl Trait` return position; generics elsewhere | Review `Box<dyn` hot loops |
+| 5.2 | Bare `trait_object` (`fn f(x: Trait)`) | `&dyn Trait` / `Box<dyn Trait>` | `bare_trait_objects` (hard error 2021) |
+| 5.3 | Over-bound `where T: Clone + Debug + Send + Sync + 'static` when only `Clone` used | Drop unused bounds | `trait_duplication_in_bounds`, `type_repetition_in_bounds` |
+| 5.4 | Generic over-engineering — single concrete caller | Concrete type until 2nd caller appears | Review |
+| 5.5 | Orphan rule violations (`impl Foreign for Foreign`) | Newtype wrapper | rustc E0117 |
+
+---
+
+## 6. Concurrency Safety
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 6.1 | `unsafe impl Send for X {}` no invariant proof | Prove `Send` (document why) or restructure | `non_send_fields_in_send_ty`, `arc_with_non_send_sync` |
+| 6.2 | Two-lock ordering undocumented → deadlock | Single lock; or document lock-ordering invariant | Review |
+| 6.3 | `Mutex` guard temp lifetime extension in `match` scrutinee | Bind `let` before match | `significant_drop_in_scrutinee` |
+| 6.4 | Atomic ordering = `SeqCst` everywhere default | `Relaxed`/`Acquire`/`Release` per actual need | Review atomics; ask if ordering not justified |
+
+---
+
+## 7. Iterators & Allocations
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 7.1 | `.collect::<Vec<_>>().iter()` re-iter | Drop `collect`; chain directly | `needless_collect` |
+| 7.2 | `.iter().cloned().collect()` | `.to_vec()` or `.clone()` | `iter_cloned_collect` |
+| 7.3 | `Vec::push` in loop no `with_capacity(n)` | Pre-allocate when size known | `slow_vector_initialization` |
+| 7.4 | `format!("{}{}", a, b)` string concat in loops | `String::with_capacity` + `push_str`, or `[a, b].concat()` | `useless_format`, `format_in_format_args` |
+| 7.5 | `BTreeMap` default | `HashMap` unless ordered iter or range queries needed | grep `BTreeMap` no `.range(` / iter |
+| 7.6 | `Vec<u8>` param when `&[u8]` works | `&[u8]` | `ptr_arg` |
+| 7.7 | `SmallVec`/`ArrayVec` opportunity missed hot path with bounded N | Stack-alloc via `SmallVec<[T; N]>` | Profile-driven |
+
+---
+
+## 8. Pattern Matching
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 8.1 | `match x { Some(_) => true, None => false }` | `.is_some()` | `redundant_pattern_matching` |
+| 8.2 | Nested `match` / `if let` | Collapse | `collapsible_match`, `collapsible_if` |
+| 8.3 | Catch-all `_ => {}` hide new enum variants | List variants explicit, or use `#[non_exhaustive]` deliberately | `wildcard_enum_match_arm`, `match_wildcard_for_single_variants` |
+| 8.4 | `if let` chain + `else` branches obscure control flow | `let-else` (Rust 1.65+) | Review |
+
+---
+
+## 9. Unsafe & FFI
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 9.1 | `unsafe` block no `// SAFETY: ...` comment | Add comment document invariant | `undocumented_unsafe_blocks` |
+| 9.2 | `mem::transmute` for trivial casts | `as` cast, `from_ne_bytes`, `*const T as *const U` | `transmute_*` family, `useless_transmute` |
+| 9.3 | Raw pointer arithmetic no bounds reasoning | `slice::get`/`get_unchecked` + invariant doc | Review |
+| 9.4 | Missing `Drop` impl on FFI handle | Implement `Drop` for cleanup | Review FFI bindings |
+
+---
+
+## 10. Cargo & Dependencies
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 10.1 | Wildcard versions (`foo = "*"` or `"0.*"`) | Pin minor: `"1.2"` | `cargo deny`; `multiple_crate_versions` |
+| 10.2 | `default-features = true` on heavy crates (tokio, serde, reqwest) | Opt-in features only | Review `Cargo.toml`; `cargo features-manager` |
+| 10.3 | Unused deps | Remove | `cargo udeps` |
+| 10.4 | Duplicated transitive deps from feature non-unification | Align feature flags; check `cargo tree -e features --duplicates` | `cargo tree` |
+| 10.5 | Hallucinated crate / wrong crate name | Verify crates.io before add | `cargo add <name>` fails fast |
+
+---
+
+## 11. Testing
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 11.1 | Only happy-path asserts | Add error-path + boundary tests | Review test coverage |
+| 11.2 | `#[should_panic]` no `expected = "..."` | Add expected substring — wrong panic still passes test | grep `#\[should_panic\]$` (no parens) |
+| 11.3 | No property tests for parsers / data structures | Add `proptest` for invariants | Review presence of `proptest` |
+| 11.4 | No snapshot tests multi-line output | Add `insta` | Review |
+| 11.5 | Tests share global state no isolation | `serial_test` or per-test setup | Review |
+| 11.6 | Mocks where integration test catch real bug | Hit real DB / real HTTP via testcontainers | Review |
+
+---
+
+## 12. Performance
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 12.1 | Alloc in hot loop | Hoist alloc; reuse buffer | Profile `flamegraph` |
+| 12.2 | `String::from` / `format!` when `&'static str` works | Use literal | `useless_format` |
+| 12.3 | Release profile missing LTO for bins | `[profile.release] lto = "thin"`, `codegen-units = 1` | Check `Cargo.toml` |
+| 12.4 | SIMD-amenable loop left scalar | Explicit `std::simd` or `wide` crate when profile-justified | Profile-driven |
+
+---
+
+## 13. Module & Visibility
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 13.1 | `use foo::*;` outside prelude | Explicit imports | `wildcard_imports` |
+| 13.2 | Over-pub items leak implementation | `pub(crate)`, `pub(super)` | `unreachable_pub` |
+| 13.3 | Re-exports no intention | Audit `pub use` chains | Review |
+
+---
+
+## 14. Lifetime & Drop Hazards
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 14.1 | Return ref into temporary | Return owned, or take `&mut` buffer | rustc; `let_and_return` |
+| 14.2 | `RefCell::borrow()` in `if let` outliving `else` branch | Drop borrow explicit | `await_holding_refcell_ref` (partial) |
+| 14.3 | `'static` lifetime sprinkled to satisfy compiler | Almost always wrong — restructure ownership | grep `'static` non-trait-object contexts |
+| 14.4 | Custom `Drop` may panic | `Drop` impls must not panic during unwinding | Review |
+
+---
+
+## 15. Hallucination & Convention Drift
+
+| # | Anti-pattern | Fix | Detect |
+|---|---|---|---|
+| 15.1 | Call non-existent stdlib method (e.g. `Vec::push_all`, `String::contains_ignore_case`) | `cargo check` catches; verify against current rustdoc | rustc E0599 |
+| 15.2 | Python/C++ idioms in Rust (getters/setters everywhere, `Self::new()` returning `Result` when infallible) | Idiomatic Rust: fields where appropriate, builder pattern when 4+ optional fields | Review |
+| 15.3 | Re-implement std (custom `Option`, custom iterator) | Use std | Review |
+| 15.4 | Wrong crate for job (using `regex` for parsing structured data) | Use `nom`/`winnow`/`serde` | Review |
+
+---
+
+## 16. Validation Workflow (run in order)
+
+```bash
+# 1. Format
+cargo fmt --check
+
+# 2. Compile cleanly
+cargo check --all-targets --all-features
+
+# 3. Lint with deny-warnings
+cargo clippy --all-targets --all-features -- -D warnings
+
+# 4. Tests
+cargo test --all-features
+
+# 5. Supply chain
+cargo deny check
+cargo audit
+
+# 6. Dead code
+cargo +nightly udeps
+
+# 7. (Optional) Mutation testing for confidence
+cargo mutants --check
+```
+
+**Iteration budget:** 3 cycles. Still fail same root error after 3 fix attempts → stop + report human. Issue architectural.
+
+---
+
+## 17. Escalation Triggers (stop and ask human)
+
+Stop + request review when:
+- Borrow-checker error needs change fn signature used in >5 call sites.
+- Add `Send`/`Sync` needs `unsafe impl` + you cannot articulate invariant in one sentence.
+- Two locks needed in same critical section + no obvious ordering exists.
+- Failing test needs change assertion to pass.
+- `clippy::pedantic` would need >20 `#[allow]` attributes.
+- Perf regression after refactor + cause not single `clone()` or alloc.
+
+---
+
+## 18. What This Checklist Does NOT Cover
+
+Out of scope; handle separately:
+- Domain logic correctness (use property tests + integration tests).
+- API ergonomics beyond Rust idioms (use design review).
+- Cross-service contracts (use schema validation, e.g. OpenAPI, protobuf).
+- Security review beyond basic dep audit (use `cargo-geiger`, `cargo-vet`, manual threat modeling).


### PR DESCRIPTION
## Summary
- Adds `ensure.npm.{script,dep,devDep,engine}` convergence actions applied after files/templates; promotes example 15 to implemented.
- Saved-plan replay with stale-plan detection (`rw apply --plan`), versioned state schema honoring `--strategy stop` on drift, and template engine list inputs + Jinja-style block trimming.
- Treats missing module manifest as empty; example test harness gains `expected_exit_code` and promotes example 12.
- Build fix: `Provider::add_to_linker::<_, HasSelf<_>>` for wasmtime 44 bindgen API.

## Test plan
- [x] `cargo test --workspace` green (19 tests)
- [x] `examples_apply_snapshot_suite` reports no stage mismatches